### PR TITLE
30 account deletion

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -196,12 +196,15 @@ services:
       - ./modules/:/modules:ro
     environment:
       - JWT_SECRET=${JWT_SECRET}
+      - TOKEN_MANAGER_SECRET=${TOKEN_MANAGER_SECRET}
     ports:
       - 127.0.0.1:4004:3000
     networks:
       - settings
       - avatars
       - db-profiles
+      - credentials
+      - tokens
 
   avatars:
     build:

--- a/documentation/backend.yaml
+++ b/documentation/backend.yaml
@@ -328,7 +328,7 @@ paths:
   /settings/profile:
     patch:
       summary: profile modification
-      description: Modify the profile associated with the JWT bearer
+      description: Modify the profile associated with the access_token bearer
       tags:
         - Settings
       requestBody:
@@ -353,5 +353,17 @@ paths:
           description: Invalid avatar
         409:
           description: Username already in use
+      security:
+        - JWT: []
+  
+  /settings/account:
+    delete:
+      summary: account deletion
+      description: Delete everything related to the access_token bearer
+      tags:
+        - Settings
+      responses:
+        204:
+          description: Sucessfull profile deletion
       security:
         - JWT: []

--- a/documentation/backend.yaml
+++ b/documentation/backend.yaml
@@ -83,7 +83,7 @@ components:
               - expire_at
 
 paths:
-  /register/:
+  /register:
     post:
       summary: account registration
       description: Create a new account using an email address and a password
@@ -109,7 +109,7 @@ paths:
         401:
           description: Failure
 
-  /auth/:
+  /auth:
     post:
       summary: login
       description: Authenticate using an email address and a password

--- a/env-generator.sh
+++ b/env-generator.sh
@@ -14,7 +14,7 @@ generate_or_use_existing_key() {
     # Check if the key already has a value in the environment
     if [ ! -z "${!key}" ]; then
         echo "$key=\"${!key}\"" >> "$TMP_FILE"
-        printf "%-${padding_length}s ✅\n" "- $key"
+        echo "- ✅ $key"
         export $key="${!key}"
     else
         # If no value is provided, prompt the user for input
@@ -25,7 +25,7 @@ generate_or_use_existing_key() {
 
         # Write the key-value pair to the environment file
         echo "$key=\"$value\"" >> "$TMP_FILE"
-        printf "%-${padding_length}s 🆕\n" "- $key"
+        echo "- 🆕 $key"
         export $key="${value}"
     fi
 }
@@ -43,7 +43,11 @@ generate() {
 
     # Write the key-value pair to the environment file
     echo "$key=\"$value\"" >> "$TMP_FILE"
-    printf "%-${padding_length}s 🆕\n" "- $key"
+    if [[ -z "${!key}" || "${value}" != "${!key}" ]]; then
+        echo "- 🆕 $key"
+    else
+        echo "- ✅ $key"
+    fi
     export $key="${value}"
 }
 
@@ -71,9 +75,6 @@ fi
 
 HOST=$(hostname | cut -d'.' -f1)
 
-echo "\n[MISC PARAMETERS] \n"
-generate MATCHMAKING_SCHEDULER_DELAY "100"
-
 printf "\n[URLs]\n"
 generate BACKEND_URL "https://${HOST}:7979"
 generate FRONTEND_URL "https://${HOST}:8080"
@@ -86,5 +87,7 @@ generate_or_use_existing_key API42_SECRET ""
 generate API42_REDIRECT_URI "https://${HOST}:7979/auth/fortytwo/callback"
 echo  ${API42_REDIRECT_URI} | xclip -selection clipboard
 
+printf "\n[MISC PARAMETERS] \n"
+generate MATCHMAKING_SCHEDULER_DELAY "100"
 
 mv $TMP_FILE $ENV_FILE

--- a/services/credentials/srcs/routes/root.js
+++ b/services/credentials/srcs/routes/root.js
@@ -112,10 +112,7 @@ export default function router(fastify, opts, done) {
     },
   };
 
-  fastify.delete(
-    "/:account_id",
-    { schema },
-    async function handler(request, reply) {
+  fastify.delete("/:account_id", { schema }, async function handler(request, reply) {
       const { account_id } = request.params;
 
       const result = db

--- a/services/frontend/src/components/Auth/LoginForm.tsx
+++ b/services/frontend/src/components/Auth/LoginForm.tsx
@@ -24,7 +24,7 @@ export default function LoginForm({
 	const handleSubmit = async (fields, clear) => {
 		const { 'login-email': email, 'login-password': password } = fields;
 
-		const response = await ft_fetch(`${config.API_URL}/auth/`, {
+		const response = await ft_fetch(`${config.API_URL}/auth`, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json'

--- a/services/frontend/src/components/Auth/RegisterForm.tsx
+++ b/services/frontend/src/components/Auth/RegisterForm.tsx
@@ -26,7 +26,7 @@ export default function RegisterForm({
 	const handleSubmit = async (fields, clear) => {
 		const { 'register-email': email, 'register-password': password } = fields;
 
-		const response = await ft_fetch(`${config.API_URL}/register/`, {
+		const response = await ft_fetch(`${config.API_URL}/register`, {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json'

--- a/services/nginx/conf/default.conf.template
+++ b/services/nginx/conf/default.conf.template
@@ -37,7 +37,7 @@ server {
     }
 
     location /register {
-        rewrite ^/register/(.*)$ /$1 break;
+        rewrite ^/register(.*)$ /$1 break;
         proxy_pass http://registration:3000;
     }
 
@@ -47,7 +47,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
 
-        rewrite ^/auth/(.*)$ /$1 break;
+        rewrite ^/auth(.*)$ /$1 break;
 
         proxy_pass http://password-auth:3000;
     }

--- a/services/settings/package-lock.json
+++ b/services/settings/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@fastify/bearer-auth": "^10.1.1",
+        "@fastify/cookie": "^11.0.2",
         "@fastify/cors": "^10.0.2",
         "@fastify/formbody": "^8.0.2",
         "@fastify/jwt": "^9.0.4",
@@ -58,6 +59,26 @@
       "license": "MIT",
       "dependencies": {
         "@fastify/error": "^4.0.0",
+        "fastify-plugin": "^5.0.0"
+      }
+    },
+    "node_modules/@fastify/cookie": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/cookie/-/cookie-11.0.2.tgz",
+      "integrity": "sha512-GWdwdGlgJxyvNv+QcKiGNevSspMQXncjMZ1J8IvuDQk0jvkzgWWZFNC2En3s+nHndZBGV8IbLwOI/sxCZw/mzA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.0",
         "fastify-plugin": "^5.0.0"
       }
     },

--- a/services/settings/package.json
+++ b/services/settings/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@fastify/bearer-auth": "^10.1.1",
+    "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^10.0.2",
     "@fastify/formbody": "^8.0.2",
     "@fastify/jwt": "^9.0.4",

--- a/services/settings/srcs/app/builder.js
+++ b/services/settings/srcs/app/builder.js
@@ -5,8 +5,9 @@ import cors from "@fastify/cors";
 import jwt from "@fastify/jwt";
 import bearerAuth from "@fastify/bearer-auth";
 import formbody from "@fastify/formbody";
+import cookie from "@fastify/cookie";
 import router from "./router.js";
-import YATT, { HttpError } from "yatt-utils";
+import { HttpError } from "yatt-utils";
 import { jwt_secret } from "./env.js";
 
 export default function build(opts = {}) {
@@ -46,6 +47,7 @@ export default function build(opts = {}) {
 
   app.register(jwt, { secret: jwt_secret });
   app.register(formbody);
+  app.register(cookie);
 
   app.register(router);
 

--- a/services/settings/srcs/app/env.js
+++ b/services/settings/srcs/app/env.js
@@ -3,3 +3,9 @@ if (!jwt_secret) {
   console.error("Missing environment variable: JWT_SECRET");
   process.exit(1);
 }
+
+export const token_manager_secret = process.env.TOKEN_MANAGER_SECRET;
+if (!token_manager_secret) {
+  console.error("Missing environment variable: TOKEN_MANAGER_SECRET");
+  process.exit(1);
+}

--- a/services/settings/srcs/app/router.js
+++ b/services/settings/srcs/app/router.js
@@ -2,9 +2,11 @@
 
 import root from "../routes/root.js";
 import profile from "../routes/profile.js";
+import account from "../routes/account.js";
 
 export default function router(fastify, opts, done) {
   fastify.register(root);
   fastify.register(profile);
+  fastify.register(account);
   done();
 }

--- a/services/settings/srcs/routes/account.js
+++ b/services/settings/srcs/routes/account.js
@@ -1,0 +1,56 @@
+"use strict";
+
+import YATT, { HttpError } from "yatt-utils";
+import { token_manager_secret } from "../app/env.js";
+
+export default function router(fastify, opts, done) {
+  const schema = {
+    // TODO: patch validation
+  }
+
+  fastify.patch("/account", { schema }, async function handler(request, reply) {
+    new HttpError.NotImplemented().send();
+  });
+
+  fastify.delete("/account", async function handler(request, reply) {
+    // Delete account from credentials database
+    await YATT.fetch(`http://credentials:3000/${request.account_id}`, {
+      method: "DELETE"
+    });
+
+    // Revoke all refresh_tokens for this account
+    await YATT.fetch(`http://token-manager:3000/${request.account_id}`, {
+      method: "DELETE",
+      headers: {
+        "Authorization": `Bearer ${token_manager_secret}`,
+      }
+    });
+
+    // Get avatars
+    const avatars = await YATT.fetch(`http://avatars:3000`, {
+      headers: {
+        "Authorization": `Bearer ${request.acess_token}`,
+      }
+    });
+
+    // Delete avatars uploaded by this account
+    await Promise.all(avatars.user.map(url => {
+      YATT.fetch(`http://avatars:3000/?url=${url}`, {
+        method: "DELETE",
+        headers: {
+          "Authorization": `Bearer ${request.acess_token}`,
+        }
+      });
+    }));
+  
+    // Delete from profile database
+    await YATT.fetch(`http://db-profiles:3000/${request.account_id}`, {
+      method: "DELETE"
+    });
+
+    reply.clearCookie("refresh_token");
+    reply.code(204).send();
+  });
+
+  done();
+}

--- a/services/token-manager/srcs/app/router.js
+++ b/services/token-manager/srcs/app/router.js
@@ -1,9 +1,11 @@
 "use strict";
 
+import root from "../routes/root.js";
 import token from "../routes/token.js";
 import refresh from "../routes/refresh.js";
 
 export default function router(fastify, opts, done) {
+  fastify.register(root);
   fastify.register(token);
   fastify.register(refresh);
   done();

--- a/services/token-manager/srcs/routes/root.js
+++ b/services/token-manager/srcs/routes/root.js
@@ -1,0 +1,26 @@
+"use strict";
+
+import { properties } from "yatt-utils";
+import db from "../app/database.js";
+
+export default function router(fastify, opts, done) {
+  let schema = {
+    params: {
+      type: 'object',
+      properties: {
+        account_id: properties.account_id,
+      },
+      required: ['account_id'],
+    },
+  }
+
+  fastify.delete("/:account_id", { schema, preHandler: fastify.verifyBearerAuth }, async function handler(request, reply) {
+    const { account_id } = request.params;
+
+    const deletion = db.prepare("DELETE FROM refresh_tokens WHERE account_id = ?").run(account_id);
+    console.log("DELETE:", { account_id, tokens: deletion.changes });
+    reply.code(204).send();
+  });
+
+  done();
+}

--- a/services/token-manager/srcs/routes/token.js
+++ b/services/token-manager/srcs/routes/token.js
@@ -13,7 +13,8 @@ export default function router(fastify, opts, done) {
       },
       required: ["account_id"],
       additionalProperties: false,
-  }};
+    }
+  };
 
   fastify.post("/:account_id", { schema, preHandler: fastify.verifyBearerAuth },
     async function handler(request, reply) {
@@ -36,15 +37,15 @@ export default function router(fastify, opts, done) {
   };
 
   fastify.post("/revoke", { schema }, async function handler(request, reply) {
-      const token = request.cookies.refresh_token;
+    const token = request.cookies.refresh_token;
 
-      reply.clearCookie("refresh_token");
-      const deletion = db.prepare("DELETE FROM refresh_tokens WHERE token = ? RETURNING *").get(token);
-      if (deletion) {
-        console.log("REVOKE:", { account_id: deletion.account_id });
-      }
-      reply.code(204).send();
+    reply.clearCookie("refresh_token");
+    const deletion = db.prepare("DELETE FROM refresh_tokens WHERE token = ? RETURNING *").get(token);
+    if (deletion) {
+      console.log("REVOKE:", { account_id: deletion.account_id });
     }
+    reply.code(204).send();
+  }
   );
 
   done();

--- a/tests/URLs.js
+++ b/tests/URLs.js
@@ -1,0 +1,2 @@
+export const apiURL = "https://127.0.0.1:7979";
+export const cdnURL = "https://127.0.0.1:8181";

--- a/tests/dummy/dummy-account.js
+++ b/tests/dummy/dummy-account.js
@@ -4,11 +4,14 @@ import crypto from "crypto";
 import request from "supertest";
 import Fastify from "fastify";
 import jwt from "@fastify/jwt"
+import { apiURL } from "../URLs";
 
 const app = Fastify();
 app.register(jwt, {
   secret: process.env.JWT_SECRET
 })
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 const registerUrL = "http://127.0.0.1:4012";
 const credentialsUrl = "http://127.0.0.1:7002";
@@ -24,7 +27,10 @@ export let users = [];
 export function createUsers(count=10) {
   afterAll(async () => {
     for (const user of users) {
-      await request(credentialsUrl).delete(`/${user.account_id}`).expect(204);
+      await request(apiURL)
+        .delete(`/settings/account`)
+        .set("Authorization", `Bearer ${user.jwt}`)
+        .expect(204);
     }
   });
   const USER_COUNT = count;

--- a/tests/srcs/db-profiles/usernames.test.js
+++ b/tests/srcs/db-profiles/usernames.test.js
@@ -1,6 +1,5 @@
 import request from "supertest";
 import crypto from "crypto";
-import { Console } from "console";
 
 const profilesURL = "http://127.0.0.1:7001"
 

--- a/tests/srcs/settings/account/deletion.test.js
+++ b/tests/srcs/settings/account/deletion.test.js
@@ -74,7 +74,7 @@ describe('Account Deletion', () => {
 
     expect(response.status).toBe(201);
     expect(response.body).toHaveProperty('url');
-    dummy.uploadedAvatar = response.body.url;
+    dummy.uploadedAvatar = response.body.url.replace("cdn-nginx", "localhost");
   });
 
   it("test avatar url", async () => {

--- a/tests/srcs/settings/account/deletion.test.js
+++ b/tests/srcs/settings/account/deletion.test.js
@@ -1,0 +1,120 @@
+import request from "supertest";
+import { apiURL } from "../../../URLs";
+import crypto from "crypto";
+import { avatarPNG } from "../../avatars/b64avatars";
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+describe('Account Deletion', () => {
+  const dummy = {
+    account_id: null,
+    jwt: null,
+    email: `dummy-account.${crypto.randomBytes(10).toString("hex")}@jest.com`,
+    password: crypto.randomBytes(4).toString("hex"),
+    username: crypto.randomBytes(4).toString("hex"),
+    avatar: null,
+  };
+
+  it("create account", async () => {
+    const response = await request(apiURL)
+      .post("/register")
+      .send({
+        email: dummy.email,
+        password: dummy.password,
+      })
+      .expect(201)
+      .expect("Content-Type", /json/);
+
+    dummy.jwt = response.body.access_token;
+  });
+
+  it("auth using password", async () => {
+    const response = await request(apiURL)
+      .post("/auth")
+      .send({
+        email: dummy.email,
+        password: dummy.password,
+      })
+      .expect(200)
+      .expect("Content-Type", /json/);
+
+    dummy.jwt = response.body.access_token;
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        access_token: expect.any(String),
+        expire_at: expect.any(String),
+      })
+    );
+  });
+
+  it("/me", async () => {
+    const response = await request(apiURL)
+      .get("/me")
+      .set("Authorization", `Bearer ${dummy.jwt}`)
+      .expect(200)
+      .expect("Content-Type", /json/);
+
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        account_id: expect.any(Number),
+        avatar: expect.any(String),
+      })
+    );
+
+    dummy.account_id = response.body.account_id;
+    dummy.avatar = response.body.avatar;
+  });
+
+  it('upload an avatar', async () => {
+    const response = await request(apiURL)
+      .post('/avatars')
+      .set("Authorization", `Bearer ${dummy.jwt}`)
+      .set('Content-Type', 'text/plain')
+      .send(avatarPNG);
+
+    expect(response.status).toBe(201);
+    expect(response.body).toHaveProperty('url');
+    dummy.uploadedAvatar = response.body.url;
+  });
+
+  it("test avatar url", async () => {
+    const response = await request(dummy.uploadedAvatar)
+      .get("")
+      .set("Authorization", `Bearer ${dummy.jwt}`)
+      .expect(200)
+      .expect("Content-Type", /image/);
+  });
+
+  it('call deletion route', async () => {
+    const response = await request(apiURL)
+      .delete('/settings/account')
+      .set("Authorization", `Bearer ${dummy.jwt}`)
+
+    expect(response.status).toBe(204);
+  });
+
+  it("should not be able to auth again", async () => {
+    const response = await request(apiURL)
+      .post("/auth")
+      .send({
+        email: dummy.email,
+        password: dummy.password,
+      })
+      .expect(401)
+  });
+
+  it("/me should not work anymore", async () => {
+    const response = await request(apiURL)
+      .get("/me")
+      .set("Authorization", `Bearer ${dummy.jwt}`)
+      .expect(404)
+      .expect("Content-Type", /json/);
+  });
+
+  it("previously uploaded avatar should not exist anymore", async () => {
+    const response = await request(dummy.uploadedAvatar)
+      .get("")
+      .set("Authorization", `Bearer ${dummy.jwt}`)
+      .expect(404)
+  });
+});


### PR DESCRIPTION
Add API `DELETE /settings/account route`, which:
- Delete account from credentials database
- Revoke all refresh_token associated with the account
- Delete all avatars uploaded by this account
- Delete the profile associated with the account

Fix API `/register/` and `/auth/` routes requiring the trailing slash 