### PR TITLE
allow credential in google auth fetch

### DIFF
--- a/services/frontend/src/components/Auth/GoogleAuthButton.tsx
+++ b/services/frontend/src/components/Auth/GoogleAuthButton.tsx
@@ -11,6 +11,7 @@ export default function GoogleAuthButton() {
 	const handleCredential = async (response: any) => {
 		const res = await ft_fetch(`${config.API_URL}/auth/google`, {
 			method: 'POST',
+			credentials: 'include',
 			headers: {
 				'Content-Type': 'application/json'
 			},


### PR DESCRIPTION
This pull request includes a small change to the `GoogleAuthButton` component. The change ensures that credentials are included in the request when posting to the Google authentication endpoint.

* [`services/frontend/src/components/Auth/GoogleAuthButton.tsx`](diffhunk://#diff-30232a60ae1abe1994cbf7bf9872969e43620683c6f50d917f9606f713b9b071R14): Added `credentials: 'include'` to the fetch request in the `handleCredential` function.