### PR TITLE
Add loader on image deletion

### DIFF
--- a/services/frontend/src/hooks/useAvatars.ts
+++ b/services/frontend/src/hooks/useAvatars.ts
@@ -10,7 +10,7 @@ interface IAvatar {
 export default function useAvatars(): {
 	avatars: IAvatar[],
 	uploadAvatar: (file: File) => void,
-	deleteAvatar: (url: string) => void
+	deleteAvatar: (url: string) => Promise<any>
 } {
 
 	const [avatars, setAvatars] = Babact.useState<{
@@ -81,6 +81,7 @@ export default function useAvatars(): {
 				user: avatars.user.filter(avatar => avatar !== url)
 			});
 		}
+		return response;
 	}
 
 	return {

--- a/services/frontend/src/ui/ImageSelector.tsx
+++ b/services/frontend/src/ui/ImageSelector.tsx
@@ -2,6 +2,7 @@ import Babact from "babact";
 import { useForm } from "../contexts/useForm";
 import useToast, { ToastType } from "../hooks/useToast";
 import WebcamModal from "./WebcamModal";
+import Spinner from "./Spinner";
 
 export type Image = {
 	url: string,
@@ -24,7 +25,7 @@ export default function ImageSelector({
 		images: Image[],
 		onChange?: (value: string) => void,
 		required?: boolean,
-		onImageRemove?: (url: string) => void,
+		onImageRemove?: (url: string) => Promise<any>,
 		defaultValue?: string,
 		webcam?: boolean,
 		[key: string]: any
@@ -55,6 +56,14 @@ export default function ImageSelector({
 		updateFieldValidity(field, true);
 	}
 
+	const [inDeletion, setInDeletion] = Babact.useState<string>(null);
+
+	const handleImageRemove = async (url: string) => {
+		setInDeletion(url);
+		await onImageRemove(url);
+		setInDeletion(null);
+	};
+
 	Babact.useEffect(() => {
 		if (defaultValue)
 			updateField(field, defaultValue);
@@ -80,13 +89,14 @@ export default function ImageSelector({
 			</label>}
 			{
 				images.map((image: Image, i: number) => (
-					<div className='image-selector-item' key={-i}>
+					<div className={`image-selector-item ${inDeletion === image.url ? 'loading' : ''}`} key={image.url}>
 						<img
 							src={image.url} alt={`image-${i}`}
 							className={fields[field].value === image.url ? 'selected' : ''}
 							onClick={() => handleImageClick(image.url)}
 						/>
-						{image.isRemovable && <i className="fa-solid fa-trash" onClick={() => onImageRemove(image.url)}/>}
+						{image.isRemovable && !inDeletion && <i className="fa-solid fa-trash" onClick={() => handleImageRemove(image.url)}/>}
+						<Spinner />
 					</div>
 				))
 			}

--- a/services/frontend/src/ui/ui.css
+++ b/services/frontend/src/ui/ui.css
@@ -480,6 +480,7 @@
 	max-height: 30vh;
 	overflow-y: auto;
 	padding: 2px;
+	box-sizing: border-box;
 }
 
 .image-selector-container img, .image-selector-container label {
@@ -528,12 +529,41 @@
 	padding: 4px;
 }
 
-.image-selector-item:hover i {
+.image-selector-item:hover i.fa-trash {
 	display: block;
 }
 
 .image-selector-item i:hover {
 	color: var(--danger-color);
+}
+
+.image-selector-item.loading img {
+	outline: none;
+}
+
+
+.image-selector-item.loading i {
+	display: none;
+}
+
+.image-selector-item.loading .spinner i {
+	display: block;
+}
+
+.image-selector-item.loading .spinner i:hover {
+	color: var(--fg-1);
+}
+
+.image-selector-item.loading .spinner{
+	position: absolute;
+	top: 0;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	width: 100%;
+	height: calc(100% - 2px);
+	background-color: rgba(0, 0, 0, 0.5);
+	border-radius: 8px;
 }
 
 /* ================================== */


### PR DESCRIPTION
This pull request includes changes to the `useAvatars` hook and the `ImageSelector` component to improve their functionality and user experience. The key changes include making the `deleteAvatar` and `onImageRemove` functions asynchronous, adding a spinner to indicate loading state during image removal, and updating the CSS for better visual feedback.

Changes to `useAvatars` hook:

* Made the `deleteAvatar` function return a `Promise` to handle asynchronous operations.
* Added a return statement to return the response of the `deleteAvatar` function.

Changes to `ImageSelector` component:

* Made the `onImageRemove` function return a `Promise` to handle asynchronous operations.
* Added a spinner component and state management to indicate the loading state during image removal. [[1]](diffhunk://#diff-06888798a131a76fc7b68401d1ce5f51f47e72eecbf899b6659ee4ed78479604R59-R66) [[2]](diffhunk://#diff-06888798a131a76fc7b68401d1ce5f51f47e72eecbf899b6659ee4ed78479604L83-R99)

CSS updates:

* Updated the CSS to handle the loading state, including hiding the trash icon and displaying the spinner.

![image](https://github.com/user-attachments/assets/e400aa46-7b2b-4e1d-b47c-6d0a5ab51f80)
