### PR TITLE
Fix team rename error message

### DIFF
--- a/services/frontend/src/components/Lobby/LobbyTeamsList.tsx
+++ b/services/frontend/src/components/Lobby/LobbyTeamsList.tsx
@@ -103,8 +103,9 @@ export default function LobbyTeamsList() {
 				<Editable
 					defaultValue={team.name ?? `Team ${i + 1}`}
 					disabled={!team.players.find(p => p.account_id === me.account_id)}
+					maxLength={20}
 					onEdit={(value) => {
-						lobby.changeTeamName(i, value);
+						lobby.changeTeamName(value);
 					}}
 				/>
 				{team.players.map((player: IPlayer, i) => (

--- a/services/frontend/src/contexts/useLobby.tsx
+++ b/services/frontend/src/contexts/useLobby.tsx
@@ -73,11 +73,10 @@ class LobbyClient extends Lobby {
 		});
 	};
 
-	changeTeamName(team_index: number, name: string) {
+	changeTeamName(name: string) {
 		this.ws.send({
 			event: 'team_name',
 			data: {
-				team_index,
 				name
 			}
 		});

--- a/services/frontend/src/ui/Editable.tsx
+++ b/services/frontend/src/ui/Editable.tsx
@@ -4,11 +4,13 @@ import Button from "./Button";
 export default function Editable({
 		defaultValue = '',
 		onEdit,
-		disabled = false
+		disabled = false,
+		maxLength = 100,
 	}: {
 		defaultValue?: string;
 		onEdit: (value: string) => void;
 		disabled?: boolean;
+		maxLength?: number;
 	}) {
 
 	const [isEditing, setIsEditing] = Babact.useState<boolean>(false);
@@ -44,6 +46,7 @@ export default function Editable({
 			onInput={(e) => setValue(e.target.value)}
 			onFocus={() => setIsEditing(true)}
 			onBlur={handleFocusOut}
+			maxLength={maxLength}
 		/>
 		{ isEditing &&
 			<Button


### PR DESCRIPTION
This pull request includes several changes to the `LobbyTeamsList`, `useLobby`, and `Editable` components to improve the functionality and user experience of the lobby feature. The most important changes include adding a maximum length restriction to team names, simplifying the `changeTeamName` method, and updating the `Editable` component to support the new maximum length property.

Enhancements to team name functionality:

* [`services/frontend/src/components/Lobby/LobbyTeamsList.tsx`](diffhunk://#diff-930905108427485313576e04c5587c8b30f9adef8f64359f7090d1df7cbfeedcR106-R108): Added a `maxLength` property to the `Editable` component to restrict team name length to 20 characters. Simplified the `onEdit` callback by removing the team index parameter.

* [`services/frontend/src/contexts/useLobby.tsx`](diffhunk://#diff-4181de209397ca1c9cab642347a51b5bc3a5cdf1e9680e519ab2ec6b04bb364cL76-L80): Updated the `changeTeamName` method in the `LobbyClient` class to remove the `team_index` parameter, simplifying the function call.

Updates to `Editable` component:

* [`services/frontend/src/ui/Editable.tsx`](diffhunk://#diff-e538570c4e5748e8b6fa81611afe808113e932c008780e5e6c28b29c006350efL7-R13): Introduced a `maxLength` property with a default value of 100 characters. Updated the input element to use this `maxLength` property. [[1]](diffhunk://#diff-e538570c4e5748e8b6fa81611afe808113e932c008780e5e6c28b29c006350efL7-R13) [[2]](diffhunk://#diff-e538570c4e5748e8b6fa81611afe808113e932c008780e5e6c28b29c006350efR49)