### PR TITLE
Remove background color if image is valid

### DIFF
--- a/services/frontend/src/ui/Avatar.tsx
+++ b/services/frontend/src/ui/Avatar.tsx
@@ -1,5 +1,4 @@
 import Babact from "babact";
-import { FollowStatus } from "../hooks/useSocials";
 
 export default function Avatar({
 		className = '',
@@ -33,10 +32,13 @@ export default function Avatar({
 		return colour
 	}
 
-	return <div className={`avatar ${className}`} style={`background-color: ${stringToColour(name)};`} {...props}>
-		<p>{initials}</p>
+	const [error, setError] = Babact.useState<boolean>(false);
+
+	return <div className={`avatar ${className}`} style={`background-color: ${error ? stringToColour(name) : 'var(--bg-2)'};`} {...props}>
+		{error && <p>{initials}</p>}
 		<img key={src} src={src} alt="avatar" onError={(e) => {
 			e.target.style.display = 'none';
+			setError(true);
 		}}/>
 		{status && <span style={`background-color: var(--${status}-color);`} />}
 		{children && <div  className='avatar-children'>{children}</div>}


### PR DESCRIPTION
This pull request includes changes to the `Avatar` component in the `services/frontend/src/ui/Avatar.tsx` file to improve its error handling and visual feedback when an image fails to load.

Key changes:

* Removed an unused import statement for `FollowStatus` from `useSocials`.
* Added a new state variable `error` to manage the error state of the avatar image.
* Updated the `Avatar` component to conditionally render the initials and change the background color based on the `error` state.
* Modified the image `onError` event handler to hide the image and set the `error` state to true.

![image](https://github.com/user-attachments/assets/6a99299a-6692-4cc9-b061-72689d44be3f)
