### PR TITLE
leave lobby on logout

### DIFF
--- a/services/frontend/src/contexts/useAuth.tsx
+++ b/services/frontend/src/contexts/useAuth.tsx
@@ -73,6 +73,8 @@ export const AuthProvider = ({ children } : {children?: any}) => {
 
 	Babact.useEffect(() => {
 		meRef.current = me;
+		if (!me && connected)
+			disconnect();
 	}, [me]);
 
 	const setMeStatus = (status: FollowStatus) => {
@@ -83,7 +85,7 @@ export const AuthProvider = ({ children } : {children?: any}) => {
 		return meRef.current;
 	};
 
-	const { connect, follows, ping, status, connected } = useSocial(setMeStatus, getMe);
+	const { connect, follows, ping, status, connected, disconnect } = useSocial(setMeStatus, getMe);
 
 	return (
 		<AuthContext.Provider

--- a/services/frontend/src/contexts/useLobby.tsx
+++ b/services/frontend/src/contexts/useLobby.tsx
@@ -94,6 +94,13 @@ export const LobbyProvider = ({ children } : { children?: any }) => {
 	const [lobby, setLobby] = Babact.useState<LobbyClient>(null);
 	const { createToast } = useToast();
 
+	const { me } = useAuth();
+
+	Babact.useEffect(() => {
+		if (!me && lobby)
+			lobby.leave();
+	}, [me]);
+
 	const navigate = useNavigate();
 
 	const onTeamNameChange = (team_index: number, name: string) => {

--- a/services/frontend/src/hooks/useSocials.tsx
+++ b/services/frontend/src/hooks/useSocials.tsx
@@ -88,7 +88,8 @@ export default function useSocial(setMeStatus: (status: FollowStatus) => void, g
 		connected: boolean,
 		connect: () => void
 		ping: () => void
-		status: (status: FollowStatus) => void
+		status: (status: FollowStatus) => void,
+		disconnect: () => void
 	} {
 
 	const [follows, setFollows] = Babact.useState<Follow[]>([]);
@@ -245,11 +246,16 @@ export default function useSocial(setMeStatus: (status: FollowStatus) => void, g
 		ws.send({event: 'update_status', data: status});
 	};
 
+	const disconnect = () => {
+		ws.close();
+	};
+
 	return {
 		follows,
 		connected: ws.connected,
 		connect,
 		ping,
 		status,
+		disconnect,
 	};
 }

--- a/services/frontend/src/ui/Editable.tsx
+++ b/services/frontend/src/ui/Editable.tsx
@@ -11,6 +11,7 @@ export default function Editable({
 		onEdit: (value: string) => void;
 		disabled?: boolean;
 		maxLength?: number;
+		[key: string]: any;
 	}) {
 
 	const [isEditing, setIsEditing] = Babact.useState<boolean>(false);


### PR DESCRIPTION
This pull request introduces several changes to improve the handling of user authentication and lobby management in the frontend services. The most important changes include adding a disconnect function to the `useSocial` hook, updating the `AuthProvider` and `LobbyProvider` components to use this function.

Enhancements to user authentication and lobby management:

* [`services/frontend/src/hooks/useSocials.tsx`](diffhunk://#diff-11bc16cddf5bde7acd686cb35ff1f08856798c10069012b7777396faa20dfddeL91-R92): Added a `disconnect` function to the `useSocial` hook to handle disconnection logic. [[1]](diffhunk://#diff-11bc16cddf5bde7acd686cb35ff1f08856798c10069012b7777396faa20dfddeL91-R92) [[2]](diffhunk://#diff-11bc16cddf5bde7acd686cb35ff1f08856798c10069012b7777396faa20dfddeR249-R259)
* [`services/frontend/src/contexts/useAuth.tsx`](diffhunk://#diff-88b979845da30901f65c9e8a6c1994f607973d531bcd5dd3d295cb94d08ab006R76-R77): Updated the `AuthProvider` component to call the `disconnect` function when the user is not authenticated. [[1]](diffhunk://#diff-88b979845da30901f65c9e8a6c1994f607973d531bcd5dd3d295cb94d08ab006R76-R77) [[2]](diffhunk://#diff-88b979845da30901f65c9e8a6c1994f607973d531bcd5dd3d295cb94d08ab006L86-R88)
* [`services/frontend/src/contexts/useLobby.tsx`](diffhunk://#diff-4181de209397ca1c9cab642347a51b5bc3a5cdf1e9680e519ab2ec6b04bb364cR97-R103): Updated the `LobbyProvider` component to leave the lobby when the user is not authenticated.