### PR TITLE
Refresh token before sse or ws connection

### DIFF
--- a/services/frontend/src/contexts/useLobby.tsx
+++ b/services/frontend/src/contexts/useLobby.tsx
@@ -220,18 +220,18 @@ export const LobbyProvider = ({ children } : { children?: any }) => {
 	});
 
 	const create = async (mode: string = 'ranked_1v1') => {
-		ws.connect(`${config.WS_URL}/lobbies/join?gamemode=${mode}&token=${localStorage.getItem("access_token")}`);
+		ws.connect(`${config.WS_URL}/lobbies/join?gamemode=${mode}`, true);
 	};
 
 	const join = async (id: string) => {
-		ws.connect(`${config.WS_URL}/lobbies/join?secret=${id}&token=${localStorage.getItem("access_token")}`);
+		ws.connect(`${config.WS_URL}/lobbies/join?secret=${id}`, true);
 	};
 
 	// TODO: Add a refresh alert to confirm leaving the lobby
 	Babact.useEffect(() => {
 		const lobby = localStorage.getItem('lobby');
 		if (lobby) {
-			ws.connect(`${config.WS_URL}/lobbies/join?secret=${lobby}&token=${localStorage.getItem("access_token")}`);
+			join(lobby);
 		}
 	}, []);
 

--- a/services/frontend/src/hooks/useSSE.ts
+++ b/services/frontend/src/hooks/useSSE.ts
@@ -37,7 +37,6 @@ export default function useSSE({
 			else
 				SSEUrl += '&';
 			SSEUrl += `access_token=${localStorage.getItem('access_token')}`;
-			console.log('SSEUrl', SSEUrl);
 		}
 		sse.current = new EventSource(SSEUrl);
 		if (onEvent) {

--- a/services/frontend/src/hooks/useSocials.tsx
+++ b/services/frontend/src/hooks/useSocials.tsx
@@ -235,7 +235,7 @@ export default function useSocial(setMeStatus: (status: FollowStatus) => void, g
 	});
 
 	const connect = () => {
-		ws.connect(`${config.WS_URL}/social/notify?access_token=${localStorage.getItem('access_token')}`);
+		ws.connect(`${config.WS_URL}/social/notify`, true);
 	};
 
 	const ping = () => {

--- a/services/frontend/src/hooks/useTournament.ts
+++ b/services/frontend/src/hooks/useTournament.ts
@@ -87,7 +87,7 @@ export default function useTournament(tournamentId: number, onFinishCallback: (i
 		if (response)
 			onSync({tournament: response});
 		if (response?.active === 1)
-			sse.connect(`${config.API_URL}/matchmaking/tournaments/${tournamentId}/notify?token=${localStorage.getItem('access_token')}`)
+			sse.connect(`${config.API_URL}/matchmaking/tournaments/${tournamentId}/notify`, true);
 	}
 
 	const onSync = ({tournament} : {tournament: Tournament}) => {

--- a/services/frontend/src/hooks/useWebSocket.ts
+++ b/services/frontend/src/hooks/useWebSocket.ts
@@ -3,7 +3,7 @@ import useFetch from "./useFetch";
 
 export type WebSocketHook = {
 	connected: boolean,
-	connect: (url: string) => void,
+	connect: (url: string, enableToken?: boolean) => void,
 	close: () => void,
 	send: (message: string | object) => void,
 }
@@ -26,12 +26,22 @@ export default function useWebSocket({
 	const [connected, setConnected] = Babact.useState<boolean>(false);
 	const { refreshToken } = useFetch();
 
-	const connect = async (url: string) => {
+	const connect = async (url: string, enableToken: boolean = false) => {
 		if (ws.current) {
 			close();
 		}
-		await refreshToken();
-		ws.current = new WebSocket(url);
+		let wsUrl = url
+		if (enableToken) {
+			await refreshToken();
+			const parsedUrl = new URL(url);
+			if (parsedUrl.search === '')
+				wsUrl += '?';
+			else
+				wsUrl += '&';
+			wsUrl += `access_token=${localStorage.getItem('access_token')}`;
+			console.log('wsUrl', wsUrl);
+		}
+		ws.current = new WebSocket(wsUrl);
 		ws.current.onopen = (event) => {
 			if (onOpen) {
 				onOpen(event);

--- a/services/frontend/src/hooks/useWebSocket.ts
+++ b/services/frontend/src/hooks/useWebSocket.ts
@@ -39,7 +39,6 @@ export default function useWebSocket({
 			else
 				wsUrl += '&';
 			wsUrl += `access_token=${localStorage.getItem('access_token')}`;
-			console.log('wsUrl', wsUrl);
 		}
 		ws.current = new WebSocket(wsUrl);
 		ws.current.onopen = (event) => {

--- a/services/lobbies/srcs/ConnectionManager.js
+++ b/services/lobbies/srcs/ConnectionManager.js
@@ -56,10 +56,10 @@ export class ConnectionManager {
   // Checks if the connection is valid and returns the corresponding lobby
   // Throws an error if the connection is invalid
   async checkConnection(socket, fastify, req) {
-    if (!req.query.token)
+    if (!req.query.access_token)
       throw WsCloseError.Unauthorized;
     try {
-      const token = req.query.token;
+      const token = req.query.access_token;
       const decoded = fastify.jwt.verify(token);
       req.account_id = decoded.account_id;
     }

--- a/services/matchmaking/srcs/routes/tournaments.js
+++ b/services/matchmaking/srcs/routes/tournaments.js
@@ -10,16 +10,16 @@ export default function router(fastify, opts, done) {
         params: { type: "object", properties: { id: { type: "number" } } },
         query: {
           type: "object",
-          required: ["token"],
+          required: ["access_token"],
           properties: {
-            token: { type: "string" },
+            access_token: { type: "string" },
           },
         },
       },
     },
     async function handler(request, reply) {
       try {
-        request.account_id = fastify.jwt.decode(request.query.token).account_id;
+        request.account_id = fastify.jwt.decode(request.query.access_token).account_id;
         if (!request.account_id) return new HttpError.Unauthorized().send(reply);
       } catch (err) {
         return new HttpError.Unauthorized().send(reply);

--- a/tests/dummy/lobbies-player.js
+++ b/tests/dummy/lobbies-player.js
@@ -63,7 +63,7 @@ export const createLobby = (user, gamemode) => {
   return new Promise((resolve, reject) => {
     let join_secret;
     const ws = request(lobbiesURL)
-      .ws(`/join?token=${user.jwt}${isGamemodeDefined ? `&gamemode=${gamemode.name}` : ""}`)
+      .ws(`/join?access_token=${user.jwt}${isGamemodeDefined ? `&gamemode=${gamemode.name}` : ""}`)
       .expectJson((message) => {
         expect(message.event).toBe("lobby");
         expect(message.data.lobby.players.length).toBe(1);
@@ -83,7 +83,7 @@ export const createLobby = (user, gamemode) => {
 export const joinLobby = (user, lobbyconnection) => {
   return new Promise((resolve, reject) => {
     const ws = request(lobbiesURL)
-      .ws(`/join?token=${user.jwt}&secret=${lobbyconnection.join_secret}`);
+      .ws(`/join?access_token=${user.jwt}&secret=${lobbyconnection.join_secret}`);
     ws.expectJson((message) => {
       expect(message.event).toBe("lobby");
       expect(

--- a/tests/srcs/lobbies/lobbies.test.js
+++ b/tests/srcs/lobbies/lobbies.test.js
@@ -313,7 +313,7 @@ describe("Join full lobby", () => {
       players.push(player);
     }
     await request(lobbiesURL)
-      .ws(`/join?token=${users[players.length].jwt}&secret=${players[0].join_secret}`)
+      .ws(`/join?access_token=${users[players.length].jwt}&secret=${players[0].join_secret}`)
       .expectClosed(4001, "LOBBY_FULL")
       .close();
     while (players.length > 0) {

--- a/tests/srcs/matchmaking/tournament.test.js
+++ b/tests/srcs/matchmaking/tournament.test.js
@@ -165,7 +165,7 @@ describe.each(tests)(
     });
     it("connect to SSE and expect tournament sync", async () => {
       sse = await createTestSSE(
-        `${apiURL}/matchmaking/tournaments/${tournament.id}/notify?token=${users[0].jwt}`
+        `${apiURL}/matchmaking/tournaments/${tournament.id}/notify?access_token=${users[0].jwt}`
       );
       await sse.expectJson("sync", (event) => {
         const event_tournament = event.tournament;


### PR DESCRIPTION
This pull request introduces a refactor to standardize how access tokens are handled across both the frontend and backend. The primary change replaces the use of `token` query parameters with `access_token`, and updates the logic for WebSocket and Server-Sent Events (SSE) connections to optionally include the token dynamically. Additionally, backend validation logic has been updated to reflect this naming convention change.

### Frontend Changes:
* **WebSocket and SSE Refactor**:
  - Updated `connect` methods in `useWebSocket` and `useSSE` hooks to accept an optional `enableToken` parameter. When enabled, the token is dynamically appended to the URL after refreshing it via `useFetch`. (`services/frontend/src/hooks/useWebSocket.ts` [[1]](diffhunk://#diff-e7c8d8d7f2c11a56de65f3fb3a496b9707f8953c26068c64283ca02efb993653L29-R44) `services/frontend/src/hooks/useSSE.ts` [[2]](diffhunk://#diff-b4242325e20a6feb3f837b88a3c611581b616e7864dd335e7d3ae556cd14d9b1L24-R42)

* **Token Parameter Standardization**:
  - Replaced `token` with `access_token` in all WebSocket and SSE connection URLs. (`services/frontend/src/hooks/useWebSocket.ts` [[1]](diffhunk://#diff-e7c8d8d7f2c11a56de65f3fb3a496b9707f8953c26068c64283ca02efb993653L29-R44) `services/frontend/src/hooks/useSSE.ts` [[2]](diffhunk://#diff-b4242325e20a6feb3f837b88a3c611581b616e7864dd335e7d3ae556cd14d9b1L24-R42)

### Backend Changes:
* **Token Validation Update**:
  - Changed backend logic to expect `access_token` instead of `token` in query parameters for connection validation. (`services/lobbies/srcs/ConnectionManager.js` [[1]](diffhunk://#diff-66da01fadca05a543a08224a85d6a658368087549ed70ef21436a3d71d7d018bL59-R62) `services/matchmaking/srcs/routes/tournaments.js` [[2]](diffhunk://#diff-3bed293d03b12242458d08cf01cb33dbaf93a3a321c659306c32f4ad7bf51d3fL13-R22)

These changes improve consistency in token handling across the application, reduce redundancy, and centralize token management logic.