### PR TITLE
Add Team class and change display team name

### DIFF
--- a/services/frontend/src/components/Lobby/LobbyTeamsList.tsx
+++ b/services/frontend/src/components/Lobby/LobbyTeamsList.tsx
@@ -5,7 +5,7 @@ import { useLobby } from "../../contexts/useLobby";
 import { useAuth } from "../../contexts/useAuth";
 import Editable from "../../ui/Editable";
 import { IPlayer } from "yatt-lobbies";
-import { ITeam } from "yatt-lobbies/dist/Lobby";
+import { Team } from "../../hooks/useTournament";
 
 class DraggableCard {
 
@@ -81,7 +81,7 @@ export default function LobbyTeamsList() {
 	const draggingCard = Babact.useRef<DraggableCard>(null);
 	const { lobby } = useLobby();
 
-	const [teams, setTeams] = Babact.useState<ITeam[]>([]);
+	const [teams, setTeams] = Babact.useState<Team[]>([]);
 
 	const { me } = useAuth();
 
@@ -162,7 +162,7 @@ export default function LobbyTeamsList() {
 			>
 				<Editable
 					key={'editable'}
-					defaultValue={team.name ?? `Team ${i + 1}`}
+					defaultValue={team.getDisplayName()}
 					disabled={!team.players.find(p => p.account_id === me.account_id)}
 					maxLength={20}
 					onEdit={(value) => {

--- a/services/frontend/src/components/Tournament/MatchCard.tsx
+++ b/services/frontend/src/components/Tournament/MatchCard.tsx
@@ -45,7 +45,7 @@ export default function MatchCard({
 							{team.players.map((player, i) =>
 								<Avatar key={i} src={player.profile.avatar} name={player.profile.username} size='xs'/>
 							)}
-							<h3>{team.name ?? `${team.players[0].profile.username}'s team`}</h3>
+							<h3>{team.getDisplayName()}</h3>
 						</div>
 						<p>{match.scores[i]}</p>
 					</div>
@@ -55,8 +55,6 @@ export default function MatchCard({
 					</div>
 
 				)}
-				{/* {Array(2 - match.teams.length).fill(0).map((_, i) =>
-				)} */}
 			</div>
 		</div>
 	)

--- a/services/frontend/src/components/Tournament/TournamentEndModal.tsx
+++ b/services/frontend/src/components/Tournament/TournamentEndModal.tsx
@@ -13,7 +13,6 @@ export default function TournamentEndModal({
 	}) {
 	
 	const winningTeam = finalMatch?.getWinnerTeam();
-	const teamName = winningTeam.name ?? winningTeam?.players[0]?.profile?.username + "'s team";
 
 	Babact.useEffect(() => {
 		const confetti = new JSConfetti();
@@ -25,7 +24,7 @@ export default function TournamentEndModal({
 
 	if (winningTeam)
 	return <div className='tournament-end-modal flex flex-col items-center justify-center gap-4'>
-		<h2><i className="fa-solid fa-trophy"></i> {teamName} has won the tournament</h2>
+		<h2><i className="fa-solid fa-trophy"></i> {winningTeam.getDisplayName()} has won the tournament</h2>
 		<div className='flex flex-col gap-2'>
 			{winningTeam.players.map((player) => (
 				<div key={player.account_id} className='flex items-center gap-2'>

--- a/services/frontend/src/contexts/useLobby.tsx
+++ b/services/frontend/src/contexts/useLobby.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from "babact-router-dom";
 import { GameMode, ILobby, IPlayer, Lobby } from "yatt-lobbies";
 import { StatusType } from "../hooks/useSocials";
 import { useAuth } from "./useAuth";
+import { Team } from "../hooks/useTournament";
 
 export class LobbyClient extends Lobby {
 
@@ -81,6 +82,10 @@ export class LobbyClient extends Lobby {
 			}
 		});
 	};
+
+	override getTeams(): Team[] {
+		return super.getTeams().map(team => new Team(team));
+	}
 }
 
 const LobbyContext = Babact.createContext<{
@@ -104,7 +109,7 @@ export const LobbyProvider = ({ children } : { children?: any }) => {
 	const navigate = useNavigate();
 
 	const onTeamNameChange = (team_index: number, name: string) => {
-		setLobby((lobby: LobbyClient) => new LobbyClient(lobby?.setTeamName(team_index, name)));
+		setLobby((lobby) => new LobbyClient(lobby?.setTeamName(team_index, name)));
 	};
 
 	const onStateChange = (state: any) => {

--- a/services/frontend/src/hooks/useTournament.ts
+++ b/services/frontend/src/hooks/useTournament.ts
@@ -27,10 +27,29 @@ export interface Tournament {
 	id: number
 }
 
+export class Team implements ITeam {
+	players: any[];
+	name: string;
+
+	constructor(team: ITeam) {
+		this.players = team.players;
+		this.name = team.name;
+	}
+
+	getDisplayName() {
+		if (this.name)
+			return this.name;
+		if (this.players.length > 0)
+			return this.players[0].profile.username + "'s team";
+		return 'Unknown';
+	}
+
+}
+
 export class Match implements IMatch {
 	team_ids: number[];
 	scores: number[];
-	teams: ITeam[];
+	teams: Team[];
 	match_id: number;
 	state: MatchState;
 	stage: number;
@@ -43,7 +62,7 @@ export class Match implements IMatch {
 		this.state = match.state;
 		this.stage = match.stage;
 		this.index = match.index;
-		this.teams = match.team_ids.map((index: number) => teams[index]);
+		this.teams = match.team_ids.map((index: number) => new Team(teams[index]));
 	}
 
 	playerTeamIndex(account_id: number) {
@@ -65,10 +84,7 @@ export class Match implements IMatch {
 	}
 
 	getOpponentTeamName(account_id: number) {
-		const enemyTeam = this.getOpponentTeam(account_id);
-		if (!enemyTeam)
-			return 'Unknown';
-		return enemyTeam.name ?? enemyTeam.players[0].profile.username + "'s team";
+		return this.getOpponentTeam(account_id).getDisplayName()
 	}
 }
 

--- a/services/frontend/src/hooks/useTournament.ts
+++ b/services/frontend/src/hooks/useTournament.ts
@@ -62,7 +62,7 @@ export class Match implements IMatch {
 		this.state = match.state;
 		this.stage = match.stage;
 		this.index = match.index;
-		this.teams = match.team_ids.map((index: number) => new Team(teams[index]));
+		this.teams = match.team_ids.map((index: number) => teams[index] && new Team(teams[index]));
 	}
 
 	playerTeamIndex(account_id: number) {
@@ -80,11 +80,13 @@ export class Match implements IMatch {
 	}
 
 	getOpponentTeam(account_id: number) {
-		return this.teams.find((team) => !team.players.some((member) => member.account_id === account_id));
+		return this.teams?.find((team) => !team.players.some((member) => member.account_id === account_id));
 	}
 
 	getOpponentTeamName(account_id: number) {
-		return this.getOpponentTeam(account_id).getDisplayName()
+		const team = this.getOpponentTeam(account_id);
+		if (!team) return 'Unknown';
+		return team.getDisplayName()
 	}
 }
 


### PR DESCRIPTION
This pull request introduces a new `Team` class to encapsulate team-related logic and replaces direct usage of the `ITeam` interface with this new class across multiple components. The changes improve code maintainability and readability by centralizing team name formatting logic within the `Team` class. Below is a summary of the most important changes:

### Introduction of the `Team` class:

* [`services/frontend/src/hooks/useTournament.ts`](diffhunk://#diff-81c62c7fd607d1f5b26db882919f685abf8525c9e0aef8eb25af4a401f60c6c8R30-R52): Added a `Team` class that implements the `ITeam` interface and includes a `getDisplayName()` method to handle team name formatting. This method ensures consistent fallback logic for team names when a name is not explicitly set.

### Integration of the `Team` class into the `LobbyClient`:

* [`services/frontend/src/contexts/useLobby.tsx`](diffhunk://#diff-4181de209397ca1c9cab642347a51b5bc3a5cdf1e9680e519ab2ec6b04bb364cR10): Added a `getTeams()` method in `LobbyClient` to return `Team` instances instead of raw `ITeam` objects, ensuring the new class is used consistently. [[1]](diffhunk://#diff-4181de209397ca1c9cab642347a51b5bc3a5cdf1e9680e519ab2ec6b04bb364cR10) [[2]](diffhunk://#diff-4181de209397ca1c9cab642347a51b5bc3a5cdf1e9680e519ab2ec6b04bb364cR85-R88)
