### PR TITLE
test: fix TOTP test 0 padding

### DIFF
--- a/tests/srcs/2fa/verify.test.js
+++ b/tests/srcs/2fa/verify.test.js
@@ -10,59 +10,59 @@ describe("2FA Router", () => {
     const lib = TOTP.generate(secret);
     const yatt = generateTOTP(secret)
 
-    expect(lib.otp.padStart(6, 0)).toBe(yatt);
+    expect(yatt).toBe(lib.otp.padStart(6, "0"));
   })
 
-  const N = 5;
+  const N = 15;
 
   describe("default, 6 digits SHA-1", () => {
-    for (let i = 0; i < N; i++) {
+    for (let i = 0; i < N; ++i) {
       it("random seed", () => {
         const secret = base32.stringify(crypto.randomBytes(20));
 
         const lib = TOTP.generate(secret);
         const yatt = generateTOTP(secret)
 
-        expect(lib.otp).toBe(yatt);
+        expect(yatt).toBe(lib.otp.padStart(6, "0"));
       })
     }
   })
 
   describe("8 digits SHA-1", () => {
-    for (let i = 0; i < N; i++) {
+    for (let i = 0; i < N; ++i) {
       it("random seed", () => {
         const secret = base32.stringify(crypto.randomBytes(20));
 
         const lib = TOTP.generate(secret, { digits: 8 });
         const yatt = generateTOTP(secret, { digits: 8 })
 
-        expect(lib.otp).toBe(yatt);
+        expect(yatt).toBe(lib.otp.padStart(8, "0"));
       })
     }
   })
 
   describe("sha256", () => {
-    for (let i = 0; i < N; i++) {
+    for (let i = 0; i < N; ++i) {
       it("random seed", () => {
         const secret = base32.stringify(crypto.randomBytes(20));
 
         const lib = TOTP.generate(secret, { algorithm: "SHA-256" });
         const yatt = generateTOTP(secret, { algorithm: "SHA-256" })
 
-        expect(lib.otp).toBe(yatt);
+        expect(yatt).toBe(lib.otp.padStart(6, "0"));
       })
     }
   })
 
   describe("60 period", () => {
-    for (let i = 0; i < N; i++) {
+    for (let i = 0; i < N; ++i) {
       it("random seed", () => {
         const secret = base32.stringify(crypto.randomBytes(20));
 
         const lib = TOTP.generate(secret, { period: 60 });
         const yatt = generateTOTP(secret, { period: 60 })
 
-        expect(lib.otp).toBe(yatt);
+        expect(yatt).toBe(lib.otp.padStart(6, "0"));
       })
     }
   })


### PR DESCRIPTION
This pull request updates the 2FA verification test suite in `verify.test.js` to improve test accuracy and consistency. Key changes include modifying the order of comparison in assertions, increasing the iteration count for test loops, and ensuring proper zero-padding for OTP values.