### PR TITLE
fix: fix avatar service missing import

### DIFF
--- a/services/avatars/srcs/app/builder.js
+++ b/services/avatars/srcs/app/builder.js
@@ -8,6 +8,7 @@ import formbody from "@fastify/formbody";
 import router from "./router.js";
 import { HttpError } from "yatt-utils";
 import { AUTHENTICATION_SECRET, CDN_SECRET } from "./env.js";
+import db from "./database.js";
 
 export default function build(opts = {}) {
   const app = Fastify(opts);


### PR DESCRIPTION
This pull request fix a missing include in the `avatar` service builder function, resulting in a crash on service shutdown