### PR TITLE
wrong useLobby deconstruction

### DIFF
--- a/services/frontend/src/hooks/useSocials.tsx
+++ b/services/frontend/src/hooks/useSocials.tsx
@@ -215,11 +215,7 @@ export default function useSocial(setMeStatus: (status: FollowStatus) => void, g
 	};
 
 	const onConnect = () => {
-		const { lobby } = useLobby();
-		if (lobby)
-			status({type: StatusType.INLOBBY, data: {...lobby, join_secret: null}});
-		else
-			status({type: StatusType.ONLINE});
+		status({type: StatusType.ONLINE});
 	};
 
 	const ws = useWebSocket({


### PR DESCRIPTION
This pull request modifies the `useSocial` hook in `services/frontend/src/hooks/useSocials.tsx` to simplify the `onConnect` function by removing unused logic related to the `useLobby` hook.

Code simplification:

* [`services/frontend/src/hooks/useSocials.tsx`](diffhunk://#diff-11bc16cddf5bde7acd686cb35ff1f08856798c10069012b7777396faa20dfddeL218-L221): Removed the conditional logic that checked for the presence of a `lobby` and updated the status accordingly. Now, the `onConnect` function directly sets the status to `ONLINE`, simplifying the code.