### PR TITLE
Disabled image selector button when limit reach.

### DIFF
--- a/services/frontend/src/components/Settings/ProfileForm.tsx
+++ b/services/frontend/src/components/Settings/ProfileForm.tsx
@@ -53,6 +53,8 @@ export default function ProfileForm({ me }: { me: any }) {
 				webcam
 				limit={5}
 				help="Your avatar is your identity on the platform. Choose one that represents you best!"
+				ignore={[me.avatar]}
+				ignoreMessage="You can't delete your current avatar"
 				tooltip={
 					<div className='settings-tooltip flex flex-col'>
 						Upload constraints:

--- a/services/frontend/src/components/Settings/Settings.tsx
+++ b/services/frontend/src/components/Settings/Settings.tsx
@@ -24,7 +24,7 @@ export default function Settings({
 				<i className="fa-solid fa-times"></i>
 			</Button>
 		</div>
-		<div className='settings-content flex scrollbar flex-col gap-8 w-full'>
+		<div className='settings-content flex flex-col gap-8 w-full'>
 			{me && <ProfileForm me={me} />}
 			{me && <AccountForm onLogout={onClose} me={me} />}
 		</div>

--- a/services/frontend/src/components/Settings/settings.css
+++ b/services/frontend/src/components/Settings/settings.css
@@ -7,7 +7,6 @@
 	width: 400px;
 	border-radius: 0;
 	opacity: 0;
-	padding: 0 32px;
 	transition: left 0.5s, opacity 0.5s;
 }
 
@@ -25,6 +24,8 @@
 	position: relative;
 	height: 100%;
 	overflow-y: auto;
+	box-sizing: border-box;
+	padding: 0 16px;
 	padding-bottom: 20vh;
 }
 

--- a/services/frontend/src/hooks/useAvatars.ts
+++ b/services/frontend/src/hooks/useAvatars.ts
@@ -19,13 +19,12 @@ export default function useAvatars(): {
 		user: string[]
 	}>(null);
 	const { ft_fetch } = useFetch();
-	const { me } = useAuth();
 
 	const mapAvatars = (avatars) => {
 		if (!avatars) return [];
 		const mappedAvatars = avatars.user.map((avatar) => ({
 				url: avatar,
-				isRemovable: me?.avatar !== avatar
+				isRemovable: true
 		}));
 		mappedAvatars.push(...avatars.default.map((avatar) => ({
 			url: avatar,

--- a/services/frontend/src/index.css
+++ b/services/frontend/src/index.css
@@ -123,6 +123,10 @@
 	width: 100%;
 }
 
+.w-max {
+	width: max-content;
+}
+
 .h-full {
 	height: 100%;
 }

--- a/services/frontend/src/ui/AvatarDeletionModal.tsx
+++ b/services/frontend/src/ui/AvatarDeletionModal.tsx
@@ -2,21 +2,28 @@ import Babact from "babact";
 import Modal from "./Modal";
 import Button from "./Button";
 import useEscape from "../hooks/useEscape";
+import PopHover from "./PopHover";
 
 export default function AvatarDeletionModal({
 		isOpen,
 		onClose,
 		onDelete,
 		imageUrl,
+		ignore = [],
+		ignoreMessage,
 	}: {
 		isOpen: boolean;
 		onClose: () => void;
 		onDelete: () => void;
 		imageUrl: string;
+		ignore?: string[];
+		ignoreMessage?: string;
 		[key: string]: any;
 	}) {
 
 	useEscape(isOpen, onClose);
+
+	const ignoredImage = ignore.find((img) => img === imageUrl);
 
 	return <Modal
 		isOpen={isOpen}
@@ -28,12 +35,17 @@ export default function AvatarDeletionModal({
 		<p>Are you sure you want to delete this avatar ?</p>
 		<img src={imageUrl}/>
 		<div className="flex justify-end gap-2 w-full">
+			<PopHover
+				content={ignoredImage ? <p className='w-max'>{ignoreMessage}</p> : null}>
+
 			<Button
+				disabled={!!ignoredImage}
 				className="danger"
 				onClick={onDelete}
-			>
+				>
 				Delete <i className="fa-solid fa-trash-can"></i>
 			</Button>
+			</PopHover>
 		</div>
 
 	</Modal>

--- a/services/frontend/src/ui/ui.css
+++ b/services/frontend/src/ui/ui.css
@@ -511,6 +511,16 @@
 	font-size: medium;
 }
 
+.image-selector-help {
+	width: 100px;
+}
+
+.image-selector label.disabled {
+	color: var(--fg-4);
+	opacity: 0.7;
+	cursor: not-allowed;
+}
+
 .image-selector label span {
 	font-size: small;
 	color: var(--danger-color);
@@ -522,8 +532,6 @@
 	display: grid;
 	grid-template-columns: repeat(auto-fit, minmax(70px, 1fr));
 	grid-gap: 8px;
-	max-height: 30vh;
-	overflow-y: auto;
 	padding: 2px;
 	box-sizing: border-box;
 }


### PR DESCRIPTION
This pull request introduces enhancements to the avatar management system, including new constraints for avatar deletion and upload limits, as well as UI/UX improvements. The most notable changes involve adding functionality to prevent the deletion of the current avatar, enforcing upload limits, and improving the styling and interactivity of the image selector.

### Avatar Management Enhancements:
* **Prevent Deletion of Current Avatar**: Added logic to `AvatarDeletionModal` and `ProfileForm` to prevent users from deleting their current avatar. A tooltip with a custom message is displayed when attempting to delete the current avatar.
![image](https://github.com/user-attachments/assets/4022003f-2d1f-4094-812d-1fc1cc5550ba)
* **Enforce Avatar Upload Limits**: Introduced a `limit` prop in `ImageSelector` to restrict the number of images users can upload. Disabled upload buttons when the limit is reached, with tooltips explaining the restriction.
![image](https://github.com/user-attachments/assets/9fc3b68e-8652-43a3-9e64-1c8cfcbf2869)
