### PR TITLE
feat: new Keyboard class to handle inputs

### DIFF
--- a/services/frontend/src/components/Babylon/Keyboard.ts
+++ b/services/frontend/src/components/Babylon/Keyboard.ts
@@ -1,0 +1,115 @@
+import { KeyState } from "./types";
+
+export default class Keyboard {
+	private _keys: Map<string, KeyState>;
+	private _downKeys: Set<string> = new Set();
+	private _autoRegister: boolean;
+
+	public constructor(autoRegister: boolean = true) {
+		this._keys = new Map();
+		this._downKeys = new Set();
+		this._autoRegister = autoRegister;
+	}
+
+	public update(): void {
+		this._keys.forEach((state, key) => {
+			if (this._downKeys.has(key)) {
+				if (state === KeyState.IDLE || state === KeyState.RELEASED) {
+					this._keys.set(key, KeyState.PRESSED);
+				} else if (state === KeyState.PRESSED) {
+					this._keys.set(key, KeyState.HELD);
+				}
+			} else {
+				if (state === KeyState.PRESSED || state === KeyState.HELD) {
+					this._keys.set(key, KeyState.RELEASED);
+				} else if (state === KeyState.RELEASED) {
+					this._keys.set(key, KeyState.IDLE);
+				}
+			}
+		});
+	}
+
+	public registerKey(key: string): void {
+		const loweredKey = key.toLowerCase();
+		if (!this._keys.has(loweredKey)) {
+			this._keys.set(loweredKey, KeyState.IDLE);
+		}
+	}
+
+	public removeKey(key: string): void {
+		const loweredKey = key.toLowerCase();
+		if (this._keys.has(loweredKey)) {
+			this._keys.delete(loweredKey);
+		}
+		if (this._downKeys.has(loweredKey)) {
+			this._downKeys.delete(loweredKey);
+		}
+	}
+
+	public keyDown(key: string): void {
+		const loweredKey = key.toLowerCase();
+		this._downKeys.add(loweredKey);
+		if (this._autoRegister && !this._keys.has(loweredKey)) {
+			this._keys.set(loweredKey, KeyState.IDLE);
+		}
+	}
+
+	public keyUp(key: string): void {
+		const loweredKey = key.toLowerCase();
+		this._downKeys.delete(loweredKey);
+	}
+
+	public isPressed(key: string): boolean {
+		const loweredKey = key.toLowerCase();
+		return this._keys.get(loweredKey) === KeyState.PRESSED;
+	}
+
+	public isHeld(key: string): boolean {
+		const loweredKey = key.toLowerCase();
+		return this._keys.get(loweredKey) === KeyState.HELD;
+	}
+
+	public isReleased(key: string): boolean {
+		const loweredKey = key.toLowerCase();
+		return this._keys.get(loweredKey) === KeyState.RELEASED;
+	}
+
+	public isIdle(key: string): boolean {
+		const loweredKey = key.toLowerCase();
+		return this._keys.get(loweredKey) === KeyState.IDLE;
+	}
+
+	public isDown(key: string): boolean {
+		const loweredKey = key.toLowerCase();
+		return this._downKeys.has(loweredKey);
+	}
+
+	public isUp(key: string): boolean {
+		const loweredKey = key.toLowerCase();
+		return !this._downKeys.has(loweredKey);
+	}
+	
+	public getState(key: string): KeyState {
+		const loweredKey = key.toLowerCase();
+		return this._keys.get(loweredKey) ?? KeyState.IDLE;
+	}
+
+	public reset(): void {
+		this._keys.forEach((_, key) => {
+			this._keys.set(key, KeyState.IDLE);
+		});
+		this._downKeys.clear();
+	}
+
+	public clear(): void {
+		this._keys.clear();
+		this._downKeys.clear();
+	}
+
+	public get keys(): Map<string, KeyState> {
+		return this._keys;
+	}
+	public get downKeys(): Set<string> {
+		return this._downKeys;
+	}
+}


### PR DESCRIPTION
This pull request introduces a new `Keyboard` class to manage keyboard input states and integrates it into the `PongClient` class. The changes simplify and improve the handling of key states while reducing repetitive code. The most important changes are summarized below:

### New `Keyboard` Class Implementation:
* Added a `Keyboard` class in `services/frontend/src/components/Babylon/Keyboard.ts` to manage key states (`IDLE`, `PRESSED`, `HELD`, `RELEASED`) and provide utility methods for key state queries and updates.

### Integration of `Keyboard` Class in `PongClient`:
* Replaced the `Map<string, KeyState>` implementation with the new `Keyboard` class in `PongClient`, simplifying key state management. [[1]](diffhunk://#diff-5b1ef1eba53a7fd9dbd7692a3f4ec555374a36b944d8410e298afad553f35702R14-R22) [[2]](diffhunk://#diff-5b1ef1eba53a7fd9dbd7692a3f4ec555374a36b944d8410e298afad553f35702L55-R56)
* Updated the `loop` method in `PongClient` to call `Keyboard.update()` for consistent key state transitions.

### Simplified Key Handling Logic:
* Replaced manual key state checks (e.g., `KeyState.HELD` or `KeyState.PRESSED`) with `Keyboard` utility methods like `isDown` for cleaner and more readable code. [[1]](diffhunk://#diff-5b1ef1eba53a7fd9dbd7692a3f4ec555374a36b944d8410e298afad553f35702L348-R328) [[2]](diffhunk://#diff-5b1ef1eba53a7fd9dbd7692a3f4ec555374a36b944d8410e298afad553f35702L362-R340)
* Updated `handleKeyDown` and `handleKeyUp` methods in `PongClient` to delegate key state changes to the `Keyboard` class, removing redundant logic.

### Code Cleanup:
* Removed commented-out and unused code related to Babylon.js objects and scenes in `PongClient`, improving code clarity.