### PR TITLE
feat: limit lobby invitations/requests to friends

### DIFF
--- a/services/credentials/srcs/routes/google.js
+++ b/services/credentials/srcs/routes/google.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 import { properties, objects } from "yatt-utils";
 import db from "../app/database.js";

--- a/services/credentials/srcs/utils/createProfile.js
+++ b/services/credentials/srcs/utils/createProfile.js
@@ -1,3 +1,5 @@
+"use strict";
+
 import YATT from "yatt-utils";
 import db from "../app/database.js";
 

--- a/services/credentials/srcs/utils/dbAction.js
+++ b/services/credentials/srcs/utils/dbAction.js
@@ -1,4 +1,4 @@
-"user strict";
+"use strict";
 
 import db from "../app/database.js";
 

--- a/services/social/srcs/utils/activityStatuses.js
+++ b/services/social/srcs/utils/activityStatuses.js
@@ -1,3 +1,5 @@
+"use strict";
+
 export const inactive = { type: "inactive" };
 export const offline = { type: "offline" };
 export const online = { type: "online" };

--- a/services/social/srcs/utils/eventsConfig.js
+++ b/services/social/srcs/utils/eventsConfig.js
@@ -1,3 +1,5 @@
+"use strict";
+
 import { properties } from "yatt-utils";
 import { EventManager } from "yatt-ws";
 

--- a/tests/dummy/social-dummy.js
+++ b/tests/dummy/social-dummy.js
@@ -99,6 +99,10 @@ export class SocialDummy {
     this.close();
     this.connect();
   };
+
+  send(payload) {
+    this.ws.send(JSON.stringify(payload));
+  };
 };
 
 export const emptyWelcome = {

--- a/tests/dummy/social-dummy.js
+++ b/tests/dummy/social-dummy.js
@@ -13,7 +13,7 @@ export class SocialDummy {
     return this.ws;
   }
 
-  disconect() {
+  disconnect() {
     this.ws.send(JSON.stringify({ event: "goodbye" })).expectClosed();
   }
 

--- a/tests/srcs/social/websocket/blocks.test.js
+++ b/tests/srcs/social/websocket/blocks.test.js
@@ -16,8 +16,8 @@ describe('Block tests', () => {
   });
 
   afterAll(async () => {
-    await user1.disconect();
-    await user2.disconect();
+    await user1.disconnect();
+    await user2.disconnect();
   })
 
   it("1 send friend request to 2", async () => {
@@ -59,9 +59,9 @@ describe('Block tests', () => {
   });
 
   it("all socials should be empty", async () => {
-    user1.disconect();
+    user1.disconnect();
     user1.connect(emptyWelcome);
-    user2.disconect();
+    user2.disconnect();
     user2.connect(emptyWelcome);
   });
 
@@ -104,9 +104,9 @@ describe('Block tests', () => {
     let response = await user2.unblock(user1);
     expect(response.statusCode).toBe(204);
 
-    user1.disconect();
+    user1.disconnect();
     user1.connect(emptyWelcome);
-    user2.disconect();
+    user2.disconnect();
     user2.connect(emptyWelcome);
   });
 
@@ -126,9 +126,9 @@ describe('Block tests', () => {
     let response = await user1.unblock(user2);
     expect(response.statusCode).toBe(204);
 
-    user1.disconect();
+    user1.disconnect();
     user1.connect(emptyWelcome);
-    user2.disconect();
+    user2.disconnect();
     user2.connect(emptyWelcome);
   });
 

--- a/tests/srcs/social/websocket/friend-request.test.js
+++ b/tests/srcs/social/websocket/friend-request.test.js
@@ -16,8 +16,8 @@ describe('Friend requests', () => {
   });
 
   afterAll(async () => {
-    await user1.disconect();
-    await user2.disconect();
+    await user1.disconnect();
+    await user2.disconnect();
   })
 
   it("1 send friend request to 2", async () => {

--- a/tests/srcs/social/websocket/keep-online.test.js
+++ b/tests/srcs/social/websocket/keep-online.test.js
@@ -1,6 +1,6 @@
 import request from "superwstest";
 import { createUsers, users } from "../../../dummy/dummy-account";
-import { inactive, offline, online } from "../../../../services/social/srcs/utils/activityStatuses";
+import { inactive, offline } from "../../../../services/social/srcs/utils/activityStatuses";
 import { apiURL, socialWS } from "../../../URLs";
 
 createUsers(2);

--- a/tests/srcs/social/websocket/lobby-invitations.test.js
+++ b/tests/srcs/social/websocket/lobby-invitations.test.js
@@ -191,14 +191,13 @@ describe('Lobby invitations', () => {
         },
       });
 
-      console.log(dummy.user.jwt);
       await dummy.expectEvent("error", {
         code: "USER_UNAVAILABLE",
         details: { account_id: users[2].account_id },
         message: "The requested user is currently offline or not accessible"
       });
 
-      dummy.disconect();
+      dummy.disconnect();
     });
   });
 });

--- a/tests/srcs/social/websocket/lobby-invitations.test.js
+++ b/tests/srcs/social/websocket/lobby-invitations.test.js
@@ -1,13 +1,19 @@
 import request from "superwstest";
 import { createUsers, users } from "../../../dummy/dummy-account";
 import { apiURL, socialWS } from "../../../URLs";
+import { SocialDummy } from "../../../dummy/social-dummy";
 
-createUsers(2);
+createUsers(3);
 
 describe('Lobby invitations', () => {
-  it("follow", async () => {
+  beforeAll(async () => {
     await request(apiURL)
-      .post(`/social/follows/${users[0].account_id}`)
+      .post(`/social/requests/${users[1].account_id}`)
+      .set('Authorization', `Bearer ${users[0].jwt}`)
+      .expect(204);
+
+    await request(apiURL)
+      .post(`/social/requests/${users[0].account_id}`)
       .set('Authorization', `Bearer ${users[1].jwt}`)
       .expect(204);
   });
@@ -18,7 +24,6 @@ describe('Lobby invitations', () => {
         .ws(`/notify?access_token=${users[1].jwt}`)
         .expectJson((message) => {
           expect(message.event).toBe("welcome");
-          expect(message.data.follows.length).toEqual(1)
         })
         .sendJson({ event: "send_lobby_invite" })
         .expectJson((message) => {
@@ -33,7 +38,6 @@ describe('Lobby invitations', () => {
         .ws(`/notify?access_token=${users[1].jwt}`)
         .expectJson((message) => {
           expect(message.event).toBe("welcome");
-          expect(message.data.follows.length).toEqual(1)
         })
         .sendJson({ event: "send_lobby_invite", data: {} })
         .expectJson((message) => {
@@ -48,7 +52,6 @@ describe('Lobby invitations', () => {
         .ws(`/notify?access_token=${users[1].jwt}`)
         .expectJson((message) => {
           expect(message.event).toBe("welcome");
-          expect(message.data.follows.length).toEqual(1)
         })
         .sendJson({ event: "send_lobby_invite", data: { account_id: users[1].account_id } })
         .expectJson((message) => {
@@ -63,7 +66,6 @@ describe('Lobby invitations', () => {
         .ws(`/notify?access_token=${users[1].jwt}`)
         .expectJson((message) => {
           expect(message.event).toBe("welcome");
-          expect(message.data.follows.length).toEqual(1)
         })
         .sendJson({ event: "send_lobby_invite", data: { account_id: users[1].account_id, gamemode: {} } })
         .expectJson((message) => {
@@ -78,7 +80,6 @@ describe('Lobby invitations', () => {
         .ws(`/notify?access_token=${users[1].jwt}`)
         .expectJson((message) => {
           expect(message.event).toBe("welcome");
-          expect(message.data.follows.length).toEqual(1)
         })
         .sendJson({ event: "send_lobby_invite", data: { account_id: "string", gamemode: {}, join_secret: "a-secret" } })
         .expectJson((message) => {
@@ -93,7 +94,6 @@ describe('Lobby invitations', () => {
         .ws(`/notify?access_token=${users[1].jwt}`)
         .expectJson((message) => {
           expect(message.event).toBe("welcome");
-          expect(message.data.follows.length).toEqual(1)
         })
         .sendJson({ event: "send_lobby_invite", data: { account_id: users[1].account_id, gamemode: 45, join_secret: "a-secret" } })
         .expectJson((message) => {
@@ -108,7 +108,6 @@ describe('Lobby invitations', () => {
         .ws(`/notify?access_token=${users[1].jwt}`)
         .expectJson((message) => {
           expect(message.event).toBe("welcome");
-          expect(message.data.follows.length).toEqual(1)
         })
         .sendJson({ event: "send_lobby_invite", data: { account_id: users[1].account_id, gamemode: {}, join_secret: {} } })
         .expectJson((message) => {
@@ -125,7 +124,6 @@ describe('Lobby invitations', () => {
         .ws(`/notify?access_token=${users[1].jwt}`)
         .expectJson((message) => {
           expect(message.event).toBe("welcome");
-          expect(message.data.follows.length).toEqual(1)
         })
         .sendJson({ event: "send_lobby_invite", data: { account_id: users[0].account_id, gamemode: {}, join_secret: "a-secret" } })
         .expectJson((message) => {
@@ -140,7 +138,6 @@ describe('Lobby invitations', () => {
         .ws(`/notify?access_token=${users[1].jwt}`)
         .expectJson((message) => {
           expect(message.event).toBe("welcome");
-          expect(message.data.follows.length).toEqual(1)
         })
         .sendJson({ event: "send_lobby_invite", data: { account_id: users[1].account_id, gamemode: {}, join_secret: "a-secret" } })
         .expectJson((message) => {
@@ -157,19 +154,17 @@ describe('Lobby invitations', () => {
         .ws(`/notify?access_token=${users[1].jwt}`)
         .expectJson((message) => {
           expect(message.event).toBe("welcome");
-          expect(message.data.follows.length).toEqual(1)
         })
 
-        setTimeout(() => {
-          const event = { event: "send_lobby_invite", data: { account_id: users[0].account_id, gamemode: { example: "2v2" }, join_secret: "a-secret" } };
-          ws1.send(JSON.stringify(event))
-        }, 3000);
+      setTimeout(() => {
+        const event = { event: "send_lobby_invite", data: { account_id: users[0].account_id, gamemode: { example: "2v2" }, join_secret: "a-secret" } };
+        ws1.send(JSON.stringify(event))
+      }, 3000);
 
       const ws0 = await request(socialWS)
         .ws(`/notify?access_token=${users[0].jwt}`)
         .expectJson((message) => {
           expect(message.event).toBe("welcome");
-          expect(message.data.follows.length).toEqual(0)
         }).expectJson((message) => {
           expect(message).toEqual({
             event: "recv_lobby_invite",
@@ -180,60 +175,30 @@ describe('Lobby invitations', () => {
             }
           })
         });
+      ws0.send(JSON.stringify({ event: "goodbye" }));
+      ws1.send(JSON.stringify({ event: "goodbye" }));
+    });
 
-        ws0.send(JSON.stringify({ event: "goodbye" }));
-        ws1.send(JSON.stringify({ event: "goodbye" }));
+    it("not a friend target", async () => {
+      const dummy = new SocialDummy(users[0]);
+      dummy.connect();
+      dummy.send({
+        event: "send_lobby_invite",
+        data: {
+          account_id: users[2].account_id,
+          gamemode: { example: "2v2" },
+          join_secret: "a-secret"
+        },
+      });
 
+      console.log(dummy.user.jwt);
+      await dummy.expectEvent("error", {
+        code: "USER_UNAVAILABLE",
+        details: { account_id: users[2].account_id },
+        message: "The requested user is currently offline or not accessible"
+      });
+
+      dummy.disconect();
     });
   });
-
-  // it("send ", async () => {
-  //   const ws1 = await request(socialWS)
-  //     .ws(`/notify?access_token=${users[1].jwt}`)
-  //     .expectJson((message) => {
-  //       expect(message.event).toBe("welcome");
-  //       expect(message.data.follows.length).toEqual(1)
-
-  //       setTimeout(() => {
-  //         ws1.send(JSON.stringify({ event: "ping" }));
-  //       }, 9000)
-  //       setTimeout(() => {
-  //         ws1.send(JSON.stringify({ event: "goodbye" }));
-  //       }, 15000)
-  //     })
-
-  //   const ws0 = await request(socialWS)
-  //     .ws(`/notify?access_token=${users[0].jwt}`)
-  //     .expectJson((message) => {
-  //       expect(message.event).toBe("welcome");
-  //       expect(message.data.follows).toEqual([
-  //         expect.objectContaining({
-  //           account_id: users[1].account_id,
-  //           profile: expect.objectContaining({
-  //             account_id: users[1].account_id,
-  //             avatar: expect.any(String),
-  //             created_at: expect.any(String),
-  //             updated_at: expect.any(String),
-  //             username: expect.any(String),
-  //           }),
-  //           status: online
-  //         })
-  //       ])
-  //     })
-  //     .expectJson((message) => {
-  //       expect(message.event).toBe("recv_status");
-  //       expect(message.data).toEqual({
-  //         account_id: users[0].account_id,
-  //         status: inactive
-  //       });
-  //     })
-  //     .expectJson((message) => {
-  //       expect(message.event).toBe("recv_status");
-  //       expect(message.data).toEqual({
-  //         account_id: users[1].account_id,
-  //         status: offline
-  //       });
-  //     })
-  //   ws0.send(JSON.stringify({ event: "goodbye" }));
-  // }, 30000);
 });

--- a/tests/srcs/social/websocket/lobby-requests.test.js
+++ b/tests/srcs/social/websocket/lobby-requests.test.js
@@ -1,15 +1,21 @@
 import request from "superwstest";
 import { createUsers, users } from "../../../dummy/dummy-account";
 import { apiURL, socialWS } from "../../../URLs";
+import { SocialDummy } from "../../../dummy/social-dummy";
 
-createUsers(2);
+createUsers(3);
 
 const event = "send_lobby_request";
 
 describe('Lobby invitations', () => {
-  it("follow", async () => {
+  beforeAll(async () => {
     await request(apiURL)
-      .post(`/social/follows/${users[0].account_id}`)
+      .post(`/social/requests/${users[1].account_id}`)
+      .set('Authorization', `Bearer ${users[0].jwt}`)
+      .expect(204);
+
+    await request(apiURL)
+      .post(`/social/requests/${users[0].account_id}`)
       .set('Authorization', `Bearer ${users[1].jwt}`)
       .expect(204);
   });
@@ -20,7 +26,6 @@ describe('Lobby invitations', () => {
         .ws(`/notify?access_token=${users[1].jwt}`)
         .expectJson((message) => {
           expect(message.event).toBe("welcome");
-          expect(message.data.follows.length).toEqual(1)
         })
         .sendJson({ event: event })
         .expectJson((message) => {
@@ -35,7 +40,6 @@ describe('Lobby invitations', () => {
         .ws(`/notify?access_token=${users[1].jwt}`)
         .expectJson((message) => {
           expect(message.event).toBe("welcome");
-          expect(message.data.follows.length).toEqual(1)
         })
         .sendJson({ event: event, data: {} })
         .expectJson((message) => {
@@ -50,7 +54,6 @@ describe('Lobby invitations', () => {
         .ws(`/notify?access_token=${users[1].jwt}`)
         .expectJson((message) => {
           expect(message.event).toBe("welcome");
-          expect(message.data.follows.length).toEqual(1)
         })
         .sendJson({ event: event, data: { account_id: users[1].account_id, extra: "param" } })
         .expectJson((message) => {
@@ -67,7 +70,6 @@ describe('Lobby invitations', () => {
         .ws(`/notify?access_token=${users[1].jwt}`)
         .expectJson((message) => {
           expect(message.event).toBe("welcome");
-          expect(message.data.follows.length).toEqual(1);
         })
         .sendJson({ event: event, data: { account_id: "string" } })
         .expectJson((message) => {
@@ -84,7 +86,6 @@ describe('Lobby invitations', () => {
         .ws(`/notify?access_token=${users[1].jwt}`)
         .expectJson((message) => {
           expect(message.event).toBe("welcome");
-          expect(message.data.follows.length).toEqual(1)
         })
         .sendJson({ event: event, data: { account_id: users[0].account_id } })
         .expectJson((message) => {
@@ -99,7 +100,6 @@ describe('Lobby invitations', () => {
         .ws(`/notify?access_token=${users[1].jwt}`)
         .expectJson((message) => {
           expect(message.event).toBe("welcome");
-          expect(message.data.follows.length).toEqual(1)
         })
         .sendJson({ event: event, data: { account_id: users[1].account_id } })
         .expectJson((message) => {
@@ -116,18 +116,21 @@ describe('Lobby invitations', () => {
         .ws(`/notify?access_token=${users[1].jwt}`)
         .expectJson((message) => {
           expect(message.event).toBe("welcome");
-          expect(message.data.follows.length).toEqual(1)
         })
 
       setTimeout(() => {
-        ws1.send(JSON.stringify({ event: event, data: { account_id: users[0].account_id } }));
+        ws1.send(JSON.stringify({
+          event: event,
+          data: {
+            account_id: users[0].account_id
+          }
+        }));
       }, 3000);
 
       const ws0 = await request(socialWS)
         .ws(`/notify?access_token=${users[0].jwt}`)
         .expectJson((message) => {
           expect(message.event).toBe("welcome");
-          expect(message.data.follows.length).toEqual(0)
         }).expectJson((message) => {
           expect(message).toEqual({
             event: "recv_lobby_request",
@@ -140,7 +143,26 @@ describe('Lobby invitations', () => {
 
       ws0.send(JSON.stringify({ event: "goodbye" }));
       ws1.send(JSON.stringify({ event: "goodbye" }));
+    });
 
+    it("not a friend target", async () => {
+      const dummy = new SocialDummy(users[0]);
+      dummy.connect();
+      dummy.send({
+        event: event,
+        data: {
+          account_id: users[2].account_id
+        }
+      });
+
+      console.log(dummy.user.jwt);
+      await dummy.expectEvent("error", {
+        code: "USER_UNAVAILABLE",
+        details: { account_id: users[2].account_id },
+        message: "The requested user is currently offline or not accessible"
+      });
+
+      dummy.disconect();
     });
   });
 });

--- a/tests/srcs/social/websocket/lobby-requests.test.js
+++ b/tests/srcs/social/websocket/lobby-requests.test.js
@@ -155,14 +155,13 @@ describe('Lobby invitations', () => {
         }
       });
 
-      console.log(dummy.user.jwt);
       await dummy.expectEvent("error", {
         code: "USER_UNAVAILABLE",
         details: { account_id: users[2].account_id },
         message: "The requested user is currently offline or not accessible"
       });
 
-      dummy.disconect();
+      dummy.disconnect();
     });
   });
 });


### PR DESCRIPTION
This pull request refactors the lobby invitation and join request functionality in the `Client` class, introduces new utility methods in `dbAction.js`, and updates related tests to align with the changes. The key changes include adding friendship validation for lobby interactions, improving code organization, and enhancing test coverage.

### Codebase Enhancements:

* **Lobby Invitation and Join Request Updates**:
  - Refactored `sendLobbyInvite` and `sendLobbyJoinRequest` methods in `Client.js` to validate friendships using the new `isFriendship` function. This ensures that only friends can send lobby invites or join requests. [[1]](diffhunk://#diff-7bd29e443df73cb9e87820645f966e16e782992d8501f10d8c625ef130440b0cL141-L191) [[2]](diffhunk://#diff-7bd29e443df73cb9e87820645f966e16e782992d8501f10d8c625ef130440b0cR216-R270)

* **Database Utility Improvements**:
  - Added the `isFriendship` function in `dbAction.js` to check if two users are friends. This function is now used in the `Client` class for validating lobby interactions.
  - Improved readability of database queries by formatting multi-parameter calls (e.g., `insert_friendship` and `delete_friendship`). [[1]](diffhunk://#diff-780e2bb26ade87505325a578df0f5a4bb85949072fc05caf995f31374a3b8253L27-R38) [[2]](diffhunk://#diff-780e2bb26ade87505325a578df0f5a4bb85949072fc05caf995f31374a3b8253R71-R92)