### PR TITLE
Cookie maxAge

### DIFF
--- a/modules/yatt-utils/srcs/http/cookies.js
+++ b/modules/yatt-utils/srcs/http/cookies.js
@@ -1,0 +1,11 @@
+const refreshTokenDuration = 7 * 24 * 60 * 60 * 1000; // 7d in milliseconds
+
+export function setRefreshTokenCookie(reply, tokens) {
+  reply.setCookie("refresh_token", tokens.refresh_token, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "strict",
+    path: "/token",
+    maxAge: refreshTokenDuration,
+  });
+};

--- a/modules/yatt-utils/srcs/index.js
+++ b/modules/yatt-utils/srcs/index.js
@@ -14,6 +14,7 @@ import profilesProperties from "./schemas/properties/profiles.js";
 import responseBodyProperties from "./schemas/properties/reponse-body.js";
 import sqlProperties from "./schemas/properties/sql.js";
 import setUpSwagger from "./swagger/setup.js";
+import { setRefreshTokenCookie } from "./http/cookies.js";
 
 const YATT = {
     fetch,
@@ -24,7 +25,8 @@ const YATT = {
     },
     patchBodyToSql,
     filterToSql,
-    orderToSql
+    orderToSql,
+    setRefreshTokenCookie,
 };
 
 export default YATT;

--- a/services/fortytwo-auth/srcs/routes/callback.js
+++ b/services/fortytwo-auth/srcs/routes/callback.js
@@ -44,13 +44,8 @@ export default function routes(fastify, opts, done) {
           throw err2;
         }
       }
-      // Redirect back to frontend
-      reply.setCookie("refresh_token", tokens.refresh_token, {
-        httpOnly: true,
-        secure: true,
-        sameSite: "strict",
-        path: "/token",
-      });
+      YATT.setRefreshTokenCookie(reply, tokens);
+      // Redirect back to frontend with access_token as query
       reply.redirect(`${FRONTEND_URL}/fortytwo?statusCode=200&token=${tokens.access_token}&expire_at=${tokens.expire_at}`);
     } catch (err) {
       if (err instanceof HttpError) {

--- a/services/google-auth/srcs/routes/root.js
+++ b/services/google-auth/srcs/routes/root.js
@@ -61,12 +61,7 @@ export default function routes(fastify, opts, done) {
         throw err;
       }
     }
-    reply.setCookie("refresh_token", tokens.refresh_token, {
-      httpOnly: true,
-      secure: true,
-      sameSite: "strict",
-      path: "/token",
-    });
+    YATT.setRefreshTokenCookie(reply, tokens);
     reply.send({
       access_token: tokens.access_token,
       expire_at: tokens.expire_at,

--- a/services/password-auth/srcs/routes/root.js
+++ b/services/password-auth/srcs/routes/root.js
@@ -96,12 +96,7 @@ export default function passwordRoutes(fastify, opts, done) {
     });
 
     // Set refresh_token cookie
-    reply.setCookie("refresh_token", tokens.refresh_token, {
-      httpOnly: true,
-      secure: true,
-      sameSite: "strict",
-      path: "/token",
-    });
+    YATT.setRefreshTokenCookie(reply, tokens);
 
     // Send access_token
     reply.send({ access_token: tokens.access_token, expire_at: tokens.expire_at });

--- a/services/registration/srcs/routes/root.js
+++ b/services/registration/srcs/routes/root.js
@@ -58,14 +58,12 @@ export default function routes(fastify, opts, done) {
       },
     }
     );
-    reply.setCookie("refresh_token", tokens.refresh_token, {
-      httpOnly: true,
-      secure: true,
-      sameSite: "strict",
-      path: "/token",
+    YATT.setRefreshTokenCookie(reply, tokens);
+    reply.code(201).send({
+      access_token: tokens.access_token,
+      expire_at: tokens.expire_at
     });
-    reply.code(201).send({ access_token: tokens.access_token, expire_at: tokens.expire_at });
-  }
+  };
 
   done();
 }

--- a/services/token-manager/srcs/routes/refresh.js
+++ b/services/token-manager/srcs/routes/refresh.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import { HttpError } from "yatt-utils";
+import YATT, { HttpError } from "yatt-utils";
 import { generateTokens } from "../utils/generate.js";
 import db from "../app/database.js";
 
@@ -38,15 +38,15 @@ export default function router(fastify, opts, done) {
     }
 
     const tokens = generateTokens(fastify, account_id);
+
     // Set new refresh_token cookie
-    reply.setCookie("refresh_token", tokens.refresh_token, {
-      httpOnly: true,
-      secure: true,
-      sameSite: "strict",
-      path: "/token",
-    });
+    YATT.setRefreshTokenCookie(reply, tokens);
+
     // Send fresh access_token
-    reply.send({ access_token: tokens.access_token, expire_at: tokens.expire_at });
+    reply.send({
+      access_token: tokens.access_token,
+      expire_at: tokens.expire_at
+    });
     console.log("REFRESH:", { account_id });
   });
 


### PR DESCRIPTION
This pull request refactors the logic for setting the `refresh_token` cookie across multiple services by introducing a reusable utility function in the `yatt-utils` module. This change improves code reusability and consistency while reducing duplication.
It also add a maxAge matching the jwt duration