### PR TITLE
feat!: deprecate DELETE /settings/account route

### DIFF
--- a/services/settings/srcs/routes/account.js
+++ b/services/settings/srcs/routes/account.js
@@ -106,48 +106,7 @@ export default function router(fastify, opts, done) {
     });
 
     reply.code(204);
-  }
-
-  fastify.delete("/account", async function handler(request, reply) {
-    const headers = {
-      "Authorization": `Bearer ${request.access_token}`,
-    }
-
-    // Delete account from credentials database
-    await YATT.fetch(`http://credentials:3000/${request.account_id}`, {
-      method: "DELETE"
-    });
-
-    // Revoke all refresh_tokens for this account
-    await YATT.fetch(`http://token-manager:3000/${request.account_id}`, {
-      method: "DELETE",
-      headers: {
-        "Authorization": `Bearer ${fastify.tokens.get("token_manager")}`,
-      }
-    });
-
-    // Get avatars
-    const avatars = await YATT.fetch(`http://avatars:3000`, { headers });
-
-    // Delete avatars uploaded by this account
-    await Promise.all(avatars.user.map(url => {
-      YATT.fetch(`http://avatars:3000/?url=${url}`, { method: "DELETE", headers });
-    }));
-    // Delete from profile database
-    await YATT.fetch(`http://db-profiles:3000/${request.account_id}`, {
-      method: "DELETE"
-    });
-
-    // Get follows
-    // const follows = await YATT.fetch("http://social:3000/follows", { headers });
-    // // Delete follows
-    // await Promise.all(follows.map(follow => {
-    //   YATT.fetch(`http://social:3000/follows/${follow.following}`, { method: "DELETE", headers })
-    // }))
-
-    reply.clearCookie("refresh_token", { path: "/token" });
-    reply.code(204).send();
-  });
+  };
 
   done();
-}
+};

--- a/tests/URLs.js
+++ b/tests/URLs.js
@@ -9,3 +9,4 @@ export const credentialsURL = "http://127.0.0.1:7002";
 export const socialWS = 'ws://127.0.0.1:4123';
 export const tokenManagerURL = "http://127.0.0.1:4002";
 export const twofaURL = "http://127.0.0.1:4052";
+export const avatarsURL = "http://127.0.0.1:4113";

--- a/tests/dummy/dummy-account.js
+++ b/tests/dummy/dummy-account.js
@@ -4,17 +4,17 @@ import crypto from "crypto";
 import request from "supertest";
 import Fastify from "fastify";
 import jwt from "@fastify/jwt"
-import { apiURL } from "../URLs";
+import { apiURL, avatarsURL, credentialsURL, dbprofilesURL, tokenManagerURL } from "../URLs";
 
 export const app = Fastify();
-app.register(jwt, { secret: process.env.AUTHENTICATION_SECRET })
-app.register(jwt, { secret: process.env.TWO_FA_SECRET, namespace: "two_fa" })
+app.register(jwt, { secret: process.env.AUTHENTICATION_SECRET });
+app.register(jwt, { secret: process.env.TWO_FA_SECRET, namespace: "two_fa" });
+app.register(jwt, { secret: process.env.TOKEN_MANAGER_SECRET, namespace: "token_manager" });
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 const registerUrL = "http://127.0.0.1:4012";
 const authUrl = "http://127.0.0.1:4022";
-const dbprofilesUrL = "http://127.0.0.1:7001"
 
 export let users = [];
 
@@ -23,10 +23,44 @@ const CREATION_TIMEOUT = 60000;
 export function createUsers(count=10) {
   afterAll(async () => {
     for (const user of users) {
-      await request(apiURL)
-        .delete(`/settings/account`)
-        .set("Authorization", `Bearer ${user.jwt}`)
-        .expect(204);
+      // Delete account from credentials database
+      let response = await request(credentialsURL)
+        .delete(`/${user.account_id}`)
+        .set("Authorization", `Bearer ${user.jwt}`);
+
+      expect(response.statusCode).toBe(204);
+
+      // Revoke all refresh_tokens for this account
+      response = await request(tokenManagerURL)
+        .delete(`/${user.account_id}`)
+        .set("Authorization", `Bearer ${app.jwt.token_manager.sign({})}`);
+
+      expect(response.statusCode).toBe(204);
+
+      // Get avatars
+      const avatars = await request(avatarsURL)
+        .get("/")
+        .set("Authorization", `Bearer ${user.jwt}`);
+
+      expect(avatars.statusCode).toBe(200);
+      expect(avatars.body).toEqual({
+        default: expect.any(Array),
+        user: expect.any(Array),
+      });
+
+      // Delete avatars uploaded by this account
+      for (const url of avatars.body.user) {
+        response = await request(apiURL)
+          .delete(`/avatars?url=${url}`)
+          .set("Authorization", `Bearer ${user.jwt}`);
+
+        expect(response.statusCode).toBe(204);
+      }
+
+      response = await request(dbprofilesURL)
+        .delete(`/${user.account_id}`);
+
+      expect(response.statusCode).toBe(204);
     }
   });
   const USER_COUNT = count;
@@ -55,7 +89,7 @@ export function createUsers(count=10) {
         .expect("Content-Type", /json/);
       dummy.jwt = response.body.access_token;
 
-      response = await request(dbprofilesUrL)
+      response = await request(dbprofilesURL)
         .patch(`/${dummy.account_id}`)
         .send({ username: dummy.username })
         .set('Authorization', `Bearer ${dummy.jwt}`)

--- a/tests/dummy/dummy-account_2fa.js
+++ b/tests/dummy/dummy-account_2fa.js
@@ -4,18 +4,18 @@ import crypto from "crypto";
 import request from "supertest";
 import Fastify from "fastify";
 import jwt from "@fastify/jwt"
-import { apiURL } from "../URLs";
+import { apiURL, credentialsURL, tokenManagerURL, dbprofilesURL, avatarsURL } from "../URLs";
 import { TOTP } from "totp-generator";
 
 export const app = Fastify();
-app.register(jwt, { secret: process.env.AUTHENTICATION_SECRET })
-app.register(jwt, { secret: process.env.TWO_FA_SECRET, namespace: "two_fa" })
+app.register(jwt, { secret: process.env.AUTHENTICATION_SECRET });
+app.register(jwt, { secret: process.env.TWO_FA_SECRET, namespace: "two_fa" });
+app.register(jwt, { secret: process.env.TOKEN_MANAGER_SECRET, namespace: "token_manager" });
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 const registerUrL = "http://127.0.0.1:4012";
 const authUrl = "http://127.0.0.1:4022";
-const dbprofilesUrL = "http://127.0.0.1:7001"
 
 export let users_2fa = [];
 
@@ -24,10 +24,44 @@ const CREATION_TIMEOUT = 60000;
 export function createUsers_2fa(count = 10) {
   afterAll(async () => {
     for (const user of users_2fa) {
-      await request(apiURL)
-        .delete(`/settings/account`)
-        .set("Authorization", `Bearer ${user.jwt}`)
-        .expect(204);
+      // Delete account from credentials database
+      let response = await request(credentialsURL)
+        .delete(`/${user.account_id}`)
+        .set("Authorization", `Bearer ${user.jwt}`);
+
+      expect(response.statusCode).toBe(204);
+
+      // Revoke all refresh_tokens for this account
+      response = await request(tokenManagerURL)
+        .delete(`/${user.account_id}`)
+        .set("Authorization", `Bearer ${app.jwt.token_manager.sign({})}`);
+
+      expect(response.statusCode).toBe(204);
+
+      // Get avatars
+      const avatars = await request(avatarsURL)
+        .get("/")
+        .set("Authorization", `Bearer ${user.jwt}`);
+
+      expect(avatars.statusCode).toBe(200);
+      expect(avatars.body).toEqual({
+        default: expect.any(Array),
+        user: expect.any(Array),
+      });
+
+      // Delete avatars uploaded by this account
+      for (const url of avatars.body.user) {
+        response = await request(apiURL)
+          .delete(`/avatars?url=${url}`)
+          .set("Authorization", `Bearer ${user.jwt}`);
+
+        expect(response.statusCode).toBe(204);
+      }
+
+      response = await request(dbprofilesURL)
+        .delete(`/${user.account_id}`);
+
+      expect(response.statusCode).toBe(204);
     }
   });
   const USER_COUNT = count;
@@ -56,7 +90,7 @@ export function createUsers_2fa(count = 10) {
         .expect("Content-Type", /json/);
       dummy.jwt = response.body.access_token;
 
-      response = await request(dbprofilesUrL)
+      response = await request(dbprofilesURL)
         .patch(`/${dummy.account_id}`)
         .send({ username: dummy.username })
         .set('Authorization', `Bearer ${dummy.jwt}`)

--- a/tests/srcs/settings/account/deletion.test.js
+++ b/tests/srcs/settings/account/deletion.test.js
@@ -1,119 +1,17 @@
 import request from "supertest";
 import { apiURL } from "../../../URLs";
-import crypto from "crypto";
-import { avatarPNG } from "../../avatars/b64avatars";
+import { createUsers, users } from "../../../dummy/dummy-account";
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
+createUsers(1);
+
 describe('Account Deletion', () => {
-  const dummy = {
-    account_id: null,
-    jwt: null,
-    email: `dummy-account.${crypto.randomBytes(10).toString("hex")}@jest.com`,
-    password: crypto.randomBytes(4).toString("hex"),
-    avatar: null,
-  };
-
-  it("create account", async () => {
+  it("deprecated route should 404", async () => {
     const response = await request(apiURL)
-      .post("/register")
-      .send({
-        email: dummy.email,
-        password: dummy.password,
-      })
-      .expect(201)
-      .expect("Content-Type", /json/);
+      .delete("/settings/account")
+      .set("Authorization", `Bearer ${users[0].jwt}`);
 
-    dummy.jwt = response.body.access_token;
-  });
-
-  it("auth using password", async () => {
-    const response = await request(apiURL)
-      .post("/auth")
-      .send({
-        email: dummy.email,
-        password: dummy.password,
-      })
-      .expect(200)
-      .expect("Content-Type", /json/);
-
-    dummy.jwt = response.body.access_token;
-    expect(response.body).toEqual(
-      expect.objectContaining({
-        access_token: expect.any(String),
-        expire_at: expect.any(String),
-      })
-    );
-  });
-
-  it("/me", async () => {
-    const response = await request(apiURL)
-      .get("/me")
-      .set("Authorization", `Bearer ${dummy.jwt}`)
-      .expect(200)
-      .expect("Content-Type", /json/);
-
-    expect(response.body).toEqual(
-      expect.objectContaining({
-        account_id: expect.any(Number),
-        avatar: expect.any(String),
-      })
-    );
-
-    dummy.account_id = response.body.account_id;
-    dummy.avatar = response.body.avatar;
-  });
-
-  it('upload an avatar', async () => {
-    const response = await request(apiURL)
-      .post('/avatars')
-      .set("Authorization", `Bearer ${dummy.jwt}`)
-      .set('Content-Type', 'text/plain')
-      .send(avatarPNG);
-
-    expect(response.status).toBe(201);
-    expect(response.body).toHaveProperty('url');
-    dummy.uploadedAvatar = response.body.url.replace("cdn-nginx", "localhost");
-  });
-
-  it("test avatar url", async () => {
-    const response = await request(dummy.uploadedAvatar)
-      .get("")
-      .set("Authorization", `Bearer ${dummy.jwt}`)
-      .expect(200)
-      .expect("Content-Type", /image/);
-  });
-
-  it('call deletion route', async () => {
-    const response = await request(apiURL)
-      .delete('/settings/account')
-      .set("Authorization", `Bearer ${dummy.jwt}`)
-
-    expect(response.status).toBe(204);
-  });
-
-  it("should not be able to auth again", async () => {
-    const response = await request(apiURL)
-      .post("/auth")
-      .send({
-        email: dummy.email,
-        password: dummy.password,
-      })
-      .expect(401)
-  });
-
-  it("/me should not work anymore", async () => {
-    const response = await request(apiURL)
-      .get("/me")
-      .set("Authorization", `Bearer ${dummy.jwt}`)
-      .expect(404)
-      .expect("Content-Type", /json/);
-  });
-
-  it("previously uploaded avatar should not exist anymore", async () => {
-    const response = await request(dummy.uploadedAvatar)
-      .get("")
-      .set("Authorization", `Bearer ${dummy.jwt}`)
-      .expect(404)
-  });
+    expect(response.statusCode).toBe(404);
+  })
 });


### PR DESCRIPTION
This pull request  the deprecates account deletion route from the settings service and updates the test suite to reflect these changes. 
### Removal of deprecated account deletion route:

* Removed the `/account` deletion route in `services/settings/srcs/routes/account.js`, including logic for deleting accounts, revoking tokens, and handling avatars.
