### PR TITLE
fix: speed not controlled when team pass

### DIFF
--- a/modules/pong/src/core/Behaviors.ts
+++ b/modules/pong/src/core/Behaviors.ts
@@ -40,6 +40,8 @@ export function ballCollision(event: CustomEventInit<{emitter: PH2D.Body, other:
 		}
 		if (this._stats.lastSideToHit !== other.side()) {
 			ballEmitter.faster();
+		} else {
+			ballEmitter.correctSpeed();
 		}
 
 		// register the hit


### PR DESCRIPTION
This pull request introduces a small change to the `ballCollision` function in `modules/pong/src/core/Behaviors.ts`. It adds a call to `ballEmitter.correctSpeed()` to ensure the ball's speed is corrected when multiple hit from the same team occur consecutively.