### PR TITLE
247 matchmaking statistics route

### DIFF
--- a/documentation/backend.yaml
+++ b/documentation/backend.yaml
@@ -142,6 +142,27 @@ components:
     light_match:
       $ref: "./asyncapi/matchmaking.yaml#/components/schemas/light_match"
 
+    route_mm_user:
+      type: array
+      items:
+        type: object
+        properties:
+          account_id:
+            $ref: "#/components/schemas/account_id"
+          gamemode:
+            $ref: "#/components/schemas/gamemode_name"
+          rating:
+            type: number
+            format: number
+            example: 1500
+          match_count:
+            type: integer
+            example: 10
+          elo_datapoints:
+            type: array
+            items:
+              type: number
+
     matchmaking_user:
       $ref: "./asyncapi/matchmaking.yaml#/components/schemas/matchmaking_user"
 
@@ -581,7 +602,7 @@ paths:
                   matchmaking_users:
                     type: array
                     items:
-                      $ref: "#/components/schemas/matchmaking_user"
+                      $ref: "#/components/schemas/route_mm_user"
                 required:
                   - account_id
                   - username
@@ -738,6 +759,29 @@ paths:
       responses:
         204:
           description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  account_id:
+                    $ref: "#/components/schemas/account_id"
+                  username:
+                    $ref: "#/components/schemas/username"
+                  avatar:
+                    $ref: "#/components/schemas/avatar"
+                  last_match:
+                    $ref: "#/components/schemas/light_match"
+                  last_tournament:
+                    $ref: "#/components/schemas/light_tournament"
+                  matchmaking_users:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/route_mm_user"
+                required:
+                  - account_id
+                  - username
+                  - avatar
         404:
           $ref: "#/components/responses/AccountNotFound"
       security:
@@ -1207,23 +1251,7 @@ paths:
                   matchmaking_users:
                     type: array
                     items:
-                      type: object
-                      properties:
-                        account_id:
-                          $ref: "#/components/schemas/account_id"
-                        gamemode:
-                          $ref: "#/components/schemas/gamemode_name"
-                        rating:
-                          type: number
-                          format: number
-                          example: 1500
-                        match_count:
-                          type: integer
-                          example: 10
-                        elo_datapoints:
-                          type: array
-                          items:
-                            type: number
+                      $ref: "#/components/schemas/route_mm_user"
         404:
           description: User not found
 

--- a/documentation/backend.yaml
+++ b/documentation/backend.yaml
@@ -1207,7 +1207,23 @@ paths:
                   matchmaking_users:
                     type: array
                     items:
-                      $ref: "#/components/schemas/matchmaking_user"
+                      type: object
+                      properties:
+                        account_id:
+                          $ref: "#/components/schemas/account_id"
+                        gamemode:
+                          $ref: "#/components/schemas/gamemode_name"
+                        rating:
+                          type: number
+                          format: number
+                          example: 1500
+                        match_count:
+                          type: integer
+                          example: 10
+                        elo_datapoints:
+                          type: array
+                          items:
+                            type: number
         404:
           description: User not found
 

--- a/services/matchmaking/srcs/routes/protected/matches.js
+++ b/services/matchmaking/srcs/routes/protected/matches.js
@@ -137,7 +137,7 @@ export default function router(fastify, opts, done) {
         update_rating.all({winning_team}, request.params.match_id, updated.gamemode);
         update_rating_end.run(request.params.match_id, updated.gamemode);
       }
-      else
+      else if (request.body.state === MatchState.DONE)
         update_match_count.run(request.params.match_id, updated.gamemode);
       reply.status(200).send(updated);
     }

--- a/services/matchmaking/srcs/routes/protected/matches.js
+++ b/services/matchmaking/srcs/routes/protected/matches.js
@@ -70,6 +70,17 @@ const update_rating_end = db.prepare(`
     AND matchmaking_users.gamemode = ?
 `);
 
+const update_match_count = db.prepare(`
+  UPDATE matchmaking_users
+    SET
+      match_count = match_count + 1
+  FROM match_players
+  WHERE
+    match_players.match_id = ?
+    AND match_players.account_id = matchmaking_users.account_id
+    AND matchmaking_users.gamemode = ?
+`);
+
 export default function router(fastify, opts, done) {
   fastify.patch(
     "/:match_id",
@@ -126,6 +137,8 @@ export default function router(fastify, opts, done) {
         update_rating.all({winning_team}, request.params.match_id, updated.gamemode);
         update_rating_end.run(request.params.match_id, updated.gamemode);
       }
+      else
+        update_match_count.run(request.params.match_id, updated.gamemode);
       reply.status(200).send(updated);
     }
   );

--- a/services/users/srcs/routes/root.js
+++ b/services/users/srcs/routes/root.js
@@ -55,6 +55,24 @@ export default function router(fastify, opts, done) {
 
     const profile = await YATT.fetch(`http://profiles:3000/${account_id}`);
 
+    try {
+      // Add game related infos
+      const { last_match, last_tournament, matchmaking_users } = await YATT.fetch(`http://matchmaking:3000/users/${account_id}`,
+        {
+          headers: {
+            Authorization: request.headers.authorization,
+          },
+        }
+      );
+
+      profile.last_match = last_match;
+      profile.last_tournament = last_tournament;
+      profile.matchmaking_users = matchmaking_users;
+    } catch (err) {
+      profile.last_match = null;
+      profile.last_tournament = null;
+      profile.matchmaking_users = [];
+    }
     reply.send(profile);
   });
 


### PR DESCRIPTION
This pull request introduces several changes to enhance matchmaking functionality, including updates to the API schema, database queries, and user profile enrichment. The most notable changes involve adding a new schema for matchmaking users, calculating Elo datapoints for ranked game modes, and integrating matchmaking data into user profiles.

### API Schema Updates:
* Added a new schema, `route_mm_user`, to represent matchmaking users with additional properties like `match_count` and `elo_datapoints`. This schema is now used in relevant API paths instead of the older `matchmaking_user` schema (`documentation/backend.yaml`). [[1]](diffhunk://#diff-42880865e967c4c9c11d89460eacbbb356ee4e77babb151766592587ee8b9f07R145-R165) [[2]](diffhunk://#diff-42880865e967c4c9c11d89460eacbbb356ee4e77babb151766592587ee8b9f07L584-R605) [[3]](diffhunk://#diff-42880865e967c4c9c11d89460eacbbb356ee4e77babb151766592587ee8b9f07L1210-R1254)
* Enhanced the API response for user-related endpoints to include detailed matchmaking data, such as `last_match`, `last_tournament`, and `matchmaking_users` (`documentation/backend.yaml`).

### Database and Backend Logic Enhancements:
* Introduced a new SQL query, `getEloDatapoints`, to calculate Elo rating trends for ranked game modes, limiting results to evenly spaced datapoints (`services/matchmaking/srcs/routes/users.js`). [[1]](diffhunk://#diff-d1d0ad8e46c812e0769b190b35471df61babcf4e08a26ded76cca158cacfe4edR8-R53) [[2]](diffhunk://#diff-d1d0ad8e46c812e0769b190b35471df61babcf4e08a26ded76cca158cacfe4edR83-R90)
* Added a query, `update_match_count`, to increment the `match_count` for users after a match is completed (`services/matchmaking/srcs/routes/protected/matches.js`). [[1]](diffhunk://#diff-f7c6a085b34cf49c060f534fbbdde94766d076672757641018790314d894730fR73-R83) [[2]](diffhunk://#diff-f7c6a085b34cf49c060f534fbbdde94766d076672757641018790314d894730fR140-R141)

### User Profile Integration:
* Updated the user profile endpoint to fetch and include matchmaking-related data (`last_match`, `last_tournament`, and `matchmaking_users`) from the matchmaking service. Added error handling to gracefully handle failures in fetching this data (`services/users/srcs/routes/root.js`).