### PR TITLE
friend request from blocked

### DIFF
--- a/services/social/srcs/utils/Client.js
+++ b/services/social/srcs/utils/Client.js
@@ -45,13 +45,16 @@ export class Client {
   };
 
   async welcome(clients, socket) {
-    // Retreive all friends / pending requests / blocked
+    // Retreive all friends / blocked / pending requests 
     const friends = dbAction.selectFriendships(this.account_id).map(f => f.account_id);
-    const pending = {
-      sent: dbAction.selectRequestsSent(this.account_id).map(r => r.account_id),
-      received: dbAction.selectRequestsReceived(this.account_id).map(r => r.account_id),
-    };
     const blocked = dbAction.selectBlocks(this.account_id).map(b => b.account_id);
+    const pending = {
+      sent: dbAction.selectRequestsSent(this.account_id)
+        .map(r => r.account_id),
+      received: dbAction.selectRequestsReceived(this.account_id)
+        .map(req => req.account_id)
+        .filter(req => !blocked.find(block => block === req)),
+    };
 
     // Fetch all related profiles
     const profiles = await fetchProfiles([...friends, ...pending.sent, ...pending.received, ...blocked]);

--- a/services/social/srcs/utils/Client.js
+++ b/services/social/srcs/utils/Client.js
@@ -45,7 +45,7 @@ export class Client {
   };
 
   async welcome(clients, socket) {
-    // Retreive all friends / blocked / pending requests 
+    // Retrieve all friends / blocked / pending requests 
     const friends = dbAction.selectFriendships(this.account_id).map(f => f.account_id);
     const blocked = dbAction.selectBlocks(this.account_id).map(b => b.account_id);
     const pending = {

--- a/services/social/srcs/utils/Client.js
+++ b/services/social/srcs/utils/Client.js
@@ -53,7 +53,7 @@ export class Client {
         .map(r => r.account_id),
       received: dbAction.selectRequestsReceived(this.account_id)
         .map(req => req.account_id)
-        .filter(req => !blocked.find(block => block === req)),
+        .filter(req => !blocked.includes(req)),
     };
 
     // Fetch all related profiles

--- a/tests/srcs/social/welcome.test.js
+++ b/tests/srcs/social/welcome.test.js
@@ -42,6 +42,14 @@ describe("Social Websocket Welcome", () => {
       });
     };
 
+    it("One blocked request me", async () => {
+      const friendRequest = await request(apiURL)
+        .post(`/social/requests/${mainUser.account_id}`)
+        .set("Authorization", `Bearer ${users[7].jwt}`)
+
+      expect(friendRequest.statusCode).toEqual(204);
+    });
+
     for (let i = 9; i < 12; ++i) {
       it("Get blocked", async () => {
         const friendRequest = await request(apiURL)
@@ -95,6 +103,7 @@ describe("Social Websocket Welcome", () => {
           expect(item).not.toHaveProperty('status');
         });
 
+        expect(message.data.pending.received.length).toEqual(3);
         expect(message.data.pending.received).toEqual(
           expect.arrayContaining(users.slice(12, 15).map(u => {
             return expect.objectContaining({ account_id: u.account_id });


### PR DESCRIPTION
This pull request refines the handling of blocked users in the "Social Websocket Welcome" functionality and enhances the corresponding test coverage. The key changes include adjusting the logic to exclude blocked users from pending friend requests and adding new test cases to validate this behavior.

### Updates to `Client.js` logic:

* Adjusted the `welcome` method to filter out blocked users from the `pending.received` friend requests. This ensures that users who have been blocked are not included in the list of pending requests. (`services/social/srcs/utils/Client.js`, [services/social/srcs/utils/Client.jsL48-L54](diffhunk://#diff-7bd29e443df73cb9e87820645f966e16e782992d8501f10d8c625ef130440b0cL48-L54))

### Enhancements to test coverage:

* Added a new test case to verify behavior when a blocked user sends a friend request, ensuring the request is handled correctly. (`tests/srcs/social/welcome.test.js`, [tests/srcs/social/welcome.test.jsR45-R52](diffhunk://#diff-e5de7e6f5ab0182b594498e3af5e3dcf540c3f24782a5fb95d56b3c82091b9b0R45-R52))
* Updated an existing test to validate that the `pending.received` array excludes blocked users and contains the expected number of entries. (`tests/srcs/social/welcome.test.js`, [tests/srcs/social/welcome.test.jsR106](diffhunk://#diff-e5de7e6f5ab0182b594498e3af5e3dcf540c3f24782a5fb95d56b3c82091b9b0R106))…me event