### PR TITLE
fix: tournaments are now also cancelled when one of it's matches is cancelled

### DIFF
--- a/services/matchmaking/srcs/Tournament.js
+++ b/services/matchmaking/srcs/Tournament.js
@@ -154,8 +154,13 @@ class TournamentMatch {
     this.tournament.broadcast("match_update", {
       match: this,
     });
+    if (newState == TournamentMatchState.CANCELLED) {
+      this.updateDB();
+      this.tournament.cancel();
+      return;
+    }
     if (newState == TournamentMatchState.DONE && oldState != newState) {
-        this.updateDB();
+      this.updateDB();
       this.tournament.manager.unregisterTournamentMatch(this);
       const winner_team = this.internal_match.teams[0].score > this.internal_match.teams[1].score ? 0 : 1;
       if (!this.nextMatch) {


### PR DESCRIPTION
This pull request includes a change to the `TournamentMatch` class in `Tournament.js` to handle a cancelled match state. Specifically, it adds logic to handle the `CANCELLED` state by updating the database and canceling the tournament.

Match state handling improvements:

* [`services/matchmaking/srcs/Tournament.js`](diffhunk://#diff-bd1c9dd7fc1351e01cdccf4c4ed0dbb0592831ab0065ac42781355987dd81913R157-R161): Added logic to handle the `CANCELLED` state in the `TournamentMatch` class. When a match transitions to this state, the database is updated, and the tournament is canceled.