### PR TITLE
Untimely overlay update

### DIFF
--- a/services/frontend/src/components/Babylon/PongClient.ts
+++ b/services/frontend/src/components/Babylon/PongClient.ts
@@ -133,7 +133,7 @@ export default class PongClient extends PONG.Pong {
 			countDown: this._state.frozen_until,
 			lastWinner: (this._state.name === "FREEZE" && this._stats) ? this._stats.lastSideToScore : null,
 			gameStatus: this._state,
-			pointsToWin: PONG.K.defaultPointsToWin,
+			pointsToWin: this._matchParameters.point_to_win,
 			activeEvents: this._activeEvents?.filter((event: PONG.PongEvent) => (!this._player || event.playerId === this._player.playerId || event.isGlobal())).map((event: PONG.PongEvent) => {
 				return {
 					type: event.type,
@@ -237,6 +237,7 @@ export default class PongClient extends PONG.Pong {
 				this._player = this._players.find((player: PONG.IPongPlayer) => player.account_id === msg.data.player.account_id) as PONG.IPongPlayer;
 				this.eventBoxSync(msg.data.match.event_boxes as PONG.IEventBoxSync[]);
 				this.eventSync(msg.data.match.activeEvents as PONG.IEventSync[]);
+				console.log("matchPrams", this._matchParameters);
 				this.updateOverlay();
 			}
 			else if (msg.event === "state") {
@@ -328,7 +329,7 @@ export default class PongClient extends PONG.Pong {
 			ball.dispose();
 		});
 		this._ballInstances = [];
-		this.updateOverlay();
+		// this.updateOverlay();
 	}
 	
 	protected switchMap(mapId: PONG.MapID) {

--- a/services/frontend/src/contexts/usePong.tsx
+++ b/services/frontend/src/contexts/usePong.tsx
@@ -10,7 +10,8 @@ const PongContext = Babact.createContext<{
 		overlay: PongOverlay,
 		togglePause: (paused: boolean) => void,
 		startGame: () => void,
-		restartGame: () => void
+		restartGame: () => void,
+		resetOverlay: () => void
 	}>();
 
 export type PongOverlay = IPongOverlay & {
@@ -74,6 +75,14 @@ export const PongProvider = ({ children } : {children?: any}) => {
 		appRef.current?.restartGame();
 	}
 
+	const resetOverlay = () => {
+		setOverlay(null);
+	}
+
+	Babact.useEffect(() => {
+		resetOverlay();
+	}, [window.location.pathname]);
+
 	return (
 		<PongContext.Provider
 			value={{
@@ -81,7 +90,8 @@ export const PongProvider = ({ children } : {children?: any}) => {
 				overlay,
 				togglePause,
 				startGame,
-				restartGame
+				restartGame,
+				resetOverlay
 			}}
 		>
 			<Babylon key="babylon" app={appRef.current}/>


### PR DESCRIPTION
This pull request introduces changes to the `PongClient` class and `usePong` context to improve functionality and maintainability. Key updates include modifying how match parameters are handled, adding a new method to reset the overlay, and cleaning up unused or unnecessary code.

### Changes to `PongClient` class:
* Updated `pointsToWin` to use `this._matchParameters.point_to_win` instead of the default constant `PONG.K.defaultPointsToWin`, ensuring match-specific parameters are applied.
* Added a `console.log` statement to debug the `this._matchParameters` object during match synchronization.
* Commented out the `this.updateOverlay()` call in the `disposeBalls` method, potentially to prevent unnecessary overlay updates during ball disposal.

### Changes to `usePong` context:
* Added a new `resetOverlay` method to reset the overlay state, improving state management.
* Integrated `resetOverlay` with a `useEffect` hook to automatically reset the overlay when the `window.location.pathname` changes.