### PR TITLE
Add mutex lock on refresh token

### DIFF
--- a/services/frontend/package-lock.json
+++ b/services/frontend/package-lock.json
@@ -10,6 +10,7 @@
         "@babylonjs/loaders": "^7.54.3",
         "@babylonjs/materials": "^7.54.3",
         "@types/qrcode": "^1.5.5",
+        "async-mutex": "^0.5.0",
         "babact": "file:../../modules/babact",
         "babact-router-dom": "file:../../modules/babact-router-dom",
         "chart.js": "^4.4.9",
@@ -975,6 +976,15 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/babact": {
       "resolved": "../../modules/babact",
@@ -4213,7 +4223,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-is": {

--- a/services/frontend/package.json
+++ b/services/frontend/package.json
@@ -15,6 +15,7 @@
     "@babylonjs/loaders": "^7.54.3",
     "@babylonjs/materials": "^7.54.3",
     "@types/qrcode": "^1.5.5",
+    "async-mutex": "^0.5.0",
     "babact": "file:../../modules/babact",
     "babact-router-dom": "file:../../modules/babact-router-dom",
     "chart.js": "^4.4.9",

--- a/services/frontend/src/contexts/useAuth.tsx
+++ b/services/frontend/src/contexts/useAuth.tsx
@@ -4,6 +4,7 @@ import config from "../config";
 import { IUser } from "../hooks/useUsers";
 import useSocial, { FriendStatus, ISocials } from "../hooks/useSocials";
 import { useNavigate } from "babact-router-dom";
+import { APIClearToken, APISetToken } from "../hooks/useAPI";
 
 const AuthContext = Babact.createContext<{
 		me: IMe,
@@ -87,19 +88,19 @@ export const AuthProvider = ({ children } : {children?: any}) => {
 	};
 
 	const auth = async (token: string, expire_at: string) => {
-		localStorage.setItem('access_token', token);
-		localStorage.setItem('expire_at', expire_at);
+		await APISetToken(token, expire_at);
 		fetchMe();
 	};
 
 	const logout = async () => {
-		localStorage.removeItem('access_token');
-		localStorage.removeItem('expire_at');
+		await APIClearToken();
 		await ft_fetch(`${config.API_URL}/token/revoke`, {
 			method: "POST",
 			credentials: "include",
 		})
 		setMe(null);
+		if (window.location.pathname !== '/' && !window.location.pathname.startsWith('/local'))
+			navigate('/');
 	};
 
 	const refresh = () => {

--- a/services/frontend/src/hooks/useAPI.ts
+++ b/services/frontend/src/hooks/useAPI.ts
@@ -59,3 +59,17 @@ export async function APIRefreshToken() {
 	}
 	release();
 }
+
+export async function APIClearToken() {
+	const release = await refreshMutex.acquire();
+	localStorage.removeItem('access_token');
+	localStorage.removeItem('expire_at');
+	release();
+}
+
+export async function APISetToken(access_token: string, expire_at: string) {
+	const release = await refreshMutex.acquire();
+	localStorage.setItem('access_token', access_token);
+	localStorage.setItem('expire_at', expire_at);
+	release();
+}

--- a/services/frontend/src/hooks/useAPI.ts
+++ b/services/frontend/src/hooks/useAPI.ts
@@ -1,3 +1,4 @@
+import { Mutex } from "async-mutex";
 import config from "../config";
 
 export async function APIFetch(url: string, fetch_options?: RequestInit) {
@@ -28,24 +29,33 @@ export async function APIFetch(url: string, fetch_options?: RequestInit) {
 	}
 }
 
+const refreshMutex = new Mutex();
+
 export async function APIRefreshToken() {
+	const release = await refreshMutex.acquire();
+
 	const expired_at = localStorage.getItem('expire_at');
-	if (!expired_at)
+	if (!expired_at || new Date(expired_at) > new Date(new Date().getTime() + 1000 * 60 * 2)) {
+		release();
 		return;
-	const expired_at_date = new Date(expired_at);
-	if (expired_at_date > new Date(new Date().getTime() + 1000 * 60 * 2))
-		return;
-	const response = await fetch(`${config.API_URL}/token/refresh`, {
-		method: 'POST',
-		credentials: 'include'
-	});
-	if (response.ok) {
+	}
+
+	try {
+
+		const response = await fetch(`${config.API_URL}/token/refresh`, {
+			method: 'POST',
+			credentials: 'include'
+		});
+		if (!response.ok)
+			throw new Error('Failed to refresh token');
 		const data = await response.json();
 		localStorage.setItem('access_token', data.access_token);
 		localStorage.setItem('expire_at', data.expire_at);
 	}
-	else {
+	catch (e: unknown) {
+		console.error('Error refreshing token', e);
 		localStorage.removeItem('access_token');
 		localStorage.removeItem('expire_at');
 	}
+	release();
 }


### PR DESCRIPTION
This pull request introduces the `async-mutex` library to manage concurrent access to shared resources and updates the `APIRefreshToken` function to ensure thread safety when refreshing tokens. The changes include dependency updates, code modifications to implement the mutex, and improvements to error handling.

### Dependency Updates:
* Added `async-mutex` as a new dependency in `services/frontend/package.json` and `services/frontend/package-lock.json`. [[1]](diffhunk://#diff-699a70f28d33903e145f50af042a20b1b35d92696ab16cc8514a1eb675b39064R13) [[2]](diffhunk://#diff-0d005dbd9d9f66983f95fa01fa375184cf69dac9ae841050c11f07ebcc6789fdR18)

### Code Enhancements:
* Updated `APIRefreshToken` in `services/frontend/src/hooks/useAPI.ts` to use a mutex (`refreshMutex`) for thread-safe token refresh operations. This ensures that only one refresh operation can occur at a time. [[1]](diffhunk://#diff-cbcb39d17da77709a0ca2129eedfc00f914d672b65265b240010d55321ca2076R1) [[2]](diffhunk://#diff-cbcb39d17da77709a0ca2129eedfc00f914d672b65265b240010d55321ca2076R32-R60)
* Improved error handling in `APIRefreshToken` by logging errors and ensuring the mutex is always released, even if an error occurs.

### Other Changes:
* Removed the `dev` field from the `tslib` dependency in `services/frontend/package-lock.json`, likely as part of housekeeping.