### PR TITLE
Change selected condition for  mode button

### DIFF
--- a/services/frontend/src/components/Online/ModeButton.tsx
+++ b/services/frontend/src/components/Online/ModeButton.tsx
@@ -38,8 +38,9 @@ export default function ModeButton({
 	}
 
 	const disabled = (lobby && gamemode?.getLobbyCapacity() < lobby.players.length) || lobby?.mode.name === gamemode.name;
+	const selected = lobby?.mode.name === gamemode.name || (lobby?.mode.type === gamemode.type && (gamemode.type === GameModeType.CUSTOM || gamemode.type === GameModeType.TOURNAMENT));
 	return <div
-		className={`mode-button flex flex-col justify-end gap-2 ${gamemode.type} ${disabled ? 'disabled' : ''} ${lobby?.mode.type === gamemode.type ? 'selected' : ''}`}
+		className={`mode-button flex flex-col justify-end gap-2 ${gamemode.type} ${disabled ? 'disabled' : ''} ${selected ? 'selected' : ''}`}
 		onClick={() => onSelect(gamemode.name)}
 	>
 		{gamemode.type === GameModeType.RANKED && <div className='mode-button-mmr flex gap-1 justify-center'>


### PR DESCRIPTION
This pull request makes a small but meaningful improvement to the `ModeButton` component in `services/frontend/src/components/Online/ModeButton.tsx`. It refines the logic for determining the "selected" state of a game mode button.

Key change:

* Updated the `selected` logic to include additional conditions, ensuring the button is marked as selected when the game mode type matches and is either `CUSTOM` or `TOURNAMENT`. This change improves consistency in the UI's behavior.