### PR TITLE
Add basic power-up icons

### DIFF
--- a/services/frontend/src/components/Babylon/PongClient.ts
+++ b/services/frontend/src/components/Babylon/PongClient.ts
@@ -34,7 +34,7 @@ export interface IPongOverlay {
 		type: PongEventType,
 		time: number,
 		isGlobal: boolean,
-		playerId?: number,
+		team: PONG.MapSide,
 	}[],
 	goals: {
 		[key: number]: {
@@ -136,12 +136,12 @@ export default class PongClient extends PONG.Pong {
 			lastWinner: (this._state.name === "FREEZE" && this._stats) ? this._stats.lastSideToScore : null,
 			gameStatus: this._state,
 			pointsToWin: PONG.K.defaultPointsToWin,
-			activeEvents: this._activeEvents?.filter((event: PONG.PongEvent) => (!this._player || event.playerId === this._player.playerId || event.isGlobal())).map((event: PONG.PongEvent) => {
+			activeEvents: this._activeEvents?.map((event: PONG.PongEvent) => {
 				return {
 					type: event.type,
 					time: event.time,
 					isGlobal: event.isGlobal(),
-					playerId: event.playerId,
+					team: (event.playerId < 2 ? PONG.MapSide.LEFT : PONG.MapSide.RIGHT),
 				}
 			}) ?? [],
 			goals: {

--- a/services/frontend/src/components/Game/GameOverlay.tsx
+++ b/services/frontend/src/components/Game/GameOverlay.tsx
@@ -53,11 +53,11 @@ export default function GameOverlay({
 					<i className="fa-solid fa-play"></i> Resume
 				</Button>
 			}
-			{globalEvents.length > 0 && globalEvents.map((e) => <div
-				className='game-overlay-powerups flex items-center justify-center gap-2'
-			>
-				<PowerUpIcon powerUp={e} />
-			</div>)}
+			{globalEvents.length > 0 &&
+				<div className='game-overlay-powerups flex items-center justify-center gap-2'>
+					{globalEvents.map((p) => <PowerUpIcon powerUp={p} key={p.type} />)}
+				</div>
+			}
 		</div>
 	</div>
 

--- a/services/frontend/src/components/Game/GameOverlay.tsx
+++ b/services/frontend/src/components/Game/GameOverlay.tsx
@@ -7,6 +7,7 @@ import Timer from './Timer';
 import WinnerRoundOverlay from './WinnerRoundOverlay';
 import WinnerMatchOverlay from './WinnerMatchOverlay';
 import WaitingPlayerOverlay from './WaitingPlayerOverlay';
+import PowerUpIcon from './PowerUpIcon';
 
 export default function GameOverlay({
 		onResume,
@@ -24,6 +25,8 @@ export default function GameOverlay({
 		return;
 
 	const displayBackground = overlay.gameStatus.isFrozen();
+
+	const globalEvents = overlay.activeEvents.filter(e => e.isGlobal);
 
 	return <div
 		className='game-overlay'
@@ -50,6 +53,11 @@ export default function GameOverlay({
 					<i className="fa-solid fa-play"></i> Resume
 				</Button>
 			}
+			{globalEvents.length > 0 && globalEvents.map((e) => <div
+				className='game-overlay-powerups flex items-center justify-center gap-2'
+			>
+				<PowerUpIcon powerUp={e} />
+			</div>)}
 		</div>
 	</div>
 

--- a/services/frontend/src/components/Game/PowerUpIcon.tsx
+++ b/services/frontend/src/components/Game/PowerUpIcon.tsx
@@ -1,0 +1,33 @@
+import Babact from "babact";
+import { MapSide } from "pong";
+import { PongEventType } from "yatt-lobbies";
+
+export interface PowerUp {
+	type: PongEventType,
+	time: number,
+	isGlobal: boolean,
+	team: MapSide,
+}
+
+export default function PowerUpIcon({ powerUp, hidden }: { powerUp: PowerUp, [key: string]: any }) {
+
+	const getPowerUpIcon = () => {
+		switch (powerUp.type) {
+			case PongEventType.MULTIBALL:
+				return <i>⚾️</i>;
+			case PongEventType.ATTRACTOR:
+				return <i>🧲</i>;
+			case PongEventType.SMALLPADDLE:
+				return <i>🔽</i>;
+			case PongEventType.ICE:
+				return <i>❄️</i>;
+			default:
+				return <i>❓</i>;
+		}
+	}
+
+	return <div className={`powerup flex items-center justify-center ${hidden ? 'hidden' : ''} ${powerUp.isGlobal ? 'global' : ''} ${powerUp.team === MapSide.LEFT ? 'left' : 'right'} ${powerUp.time < 5 ? 'warning' : ''}`}>
+		{getPowerUpIcon()}
+		{Math.floor(powerUp.time)}
+	</div>
+}

--- a/services/frontend/src/components/Game/PowerUpIcon.tsx
+++ b/services/frontend/src/components/Game/PowerUpIcon.tsx
@@ -26,8 +26,9 @@ export default function PowerUpIcon({ powerUp, hidden }: { powerUp: PowerUp, [ke
 		}
 	}
 
-	return <div className={`powerup flex items-center justify-center ${hidden ? 'hidden' : ''} ${powerUp.isGlobal ? 'global' : ''} ${powerUp.team === MapSide.LEFT ? 'left' : 'right'} ${powerUp.time < 5 ? 'warning' : ''}`}>
+	const warning = powerUp.time < 5 && powerUp.time >= 0;
+
+	return <div className={`powerup flex items-center justify-center ${hidden ? 'hidden' : ''} ${powerUp.isGlobal ? 'global' : ''} ${powerUp.team === MapSide.LEFT ? 'left' : 'right'} ${warning ? 'warning' : ''}`}>
 		{getPowerUpIcon()}
-		{Math.floor(powerUp.time)}
 	</div>
 }

--- a/services/frontend/src/components/Game/Scores.tsx
+++ b/services/frontend/src/components/Game/Scores.tsx
@@ -3,7 +3,8 @@ import Card from "../../ui/Card";
 import './game.css'
 import { usePong } from "../../contexts/usePong";
 import Avatar from "../../ui/Avatar";
-import { PongState } from "pong";
+import { MapSide, PongState } from "pong";
+import PowerUpIcon from "./PowerUpIcon";
 
 export default function Scores() {
 
@@ -32,7 +33,15 @@ export default function Scores() {
 		}
 	}, [overlay.scores[0], overlay.scores[1]]);
 
-	return <Card className='scores'>
+	const leftEvent = overlay.activeEvents.filter(e => e.team === MapSide.LEFT).filter(e => !e.isGlobal);
+	const rightEvent = overlay.activeEvents.filter(e => e.team === MapSide.RIGHT).filter(e => !e.isGlobal);
+
+	return <div className='scores-container flex items-center justify-center gap-4'>
+		<div className='score-events left flex items-center justify-center gap-2'>
+			{leftEvent.map((event) => <PowerUpIcon powerUp={event}/>)}
+			{rightEvent.map((event) => <PowerUpIcon powerUp={event} hidden/>)}
+		</div>
+		<Card className='scores'>
 		<div className="flex flex-row gap-2 items-center flex-1">
 			{ overlay.teams.length > 1 &&
 				<div className="flex items-center gap-2">
@@ -48,7 +57,7 @@ export default function Scores() {
 			<div className='score flex flex-col gap-2 justify-center items-center'>
 				<div
 					className='flex gap-2 justify-center items-center w-full'
-				>
+					>
 					{overlay.teams.length > 1 &&<div className="score-team-name flex flex-col">
 						<p>{overlay.teams[0].getDisplayName()}</p>
 						<p>{overlay.teams[1].getDisplayName()}</p>
@@ -63,7 +72,7 @@ export default function Scores() {
 					{scores && scores.map((_, index) => <span
 						className={`score-frame ${index === goal ? 'goal' : ''} ${_} ${index === pulseIndex ? 'pulse' : ''}`}
 						key={index}
-					/>)}
+						/>)}
 				</div>
 			</div>
 			{ overlay.teams.length > 1 &&
@@ -82,4 +91,9 @@ export default function Scores() {
 			{Math.round(overlay.time / 60).toString().padStart(2, '0')} : {Math.round(overlay.time % 60).toString().padStart(2, '0')}
 		</Card>
 	</Card>
+		<div className='score-events right flex items-center justify-center gap-2'>
+			{rightEvent.map((event) => <PowerUpIcon powerUp={event}/>)}
+			{leftEvent.map((event) => <PowerUpIcon powerUp={event} hidden/>)}
+		</div>
+	</div>
 }

--- a/services/frontend/src/components/Game/Scores.tsx
+++ b/services/frontend/src/components/Game/Scores.tsx
@@ -33,8 +33,8 @@ export default function Scores() {
 		}
 	}, [overlay.scores[0], overlay.scores[1]]);
 
-	const leftEvent = overlay.activeEvents.filter(e => e.team === MapSide.LEFT).filter(e => !e.isGlobal);
-	const rightEvent = overlay.activeEvents.filter(e => e.team === MapSide.RIGHT).filter(e => !e.isGlobal);
+	const leftEvent = overlay.activeEvents.filter(e => e.team === MapSide.LEFT && !e.isGlobal);
+	const rightEvent = overlay.activeEvents.filter(e => e.team === MapSide.RIGHT && !e.isGlobal);
 
 	return <div className='scores-container flex items-center justify-center gap-4'>
 		<div className='score-events left flex items-center justify-center gap-2'>

--- a/services/frontend/src/components/Game/game.css
+++ b/services/frontend/src/components/Game/game.css
@@ -1,7 +1,11 @@
-.scores {
-	padding: 0;
+.scores-container {
+	position: relative;
 	margin-top: 16px;
 	z-index: 10;
+}
+
+.scores {
+	padding: 0;
 	padding: 16px;
 	border-left: 4px solid var(--team-1-color);
 	border-right: 4px solid var(--team-2-color);
@@ -92,6 +96,18 @@
 .scores p {
 	font-size: large;
 	width: 100%;
+}
+
+.score-events {
+
+}
+
+.score-events.left {
+	
+}
+
+.score-events.right {
+	
 }
 
 /* local start modal */
@@ -205,4 +221,40 @@
 
 .game-overlay-content.background {
 	background-color: color-mix(in srgb, var(--bg-1), transparent 50%);
+}
+
+/* PowerUp */
+
+.powerup {
+	aspect-ratio: 1;
+	width: 64px;
+	border-radius: 8px;
+	background-color: var(--bg-1);
+}
+
+.powerup.hidden {
+	opacity: 0;
+}
+
+.powerup.warning {
+	animation: fadeInOut 1s ease-in-out infinite;
+}
+
+@keyframes fadeInOut {
+	0% {
+		opacity: 0;
+	}
+	50% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0;
+	}
+}
+
+.game-overlay-powerups {
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	padding: 8px;
 }

--- a/services/frontend/src/components/Game/game.css
+++ b/services/frontend/src/components/Game/game.css
@@ -230,6 +230,7 @@
 	width: 64px;
 	border-radius: 8px;
 	background-color: var(--bg-1);
+	font-size: x-large;
 }
 
 .powerup.hidden {
@@ -238,6 +239,10 @@
 
 .powerup.warning {
 	animation: fadeInOut 1s ease-in-out infinite;
+}
+
+.powerup.warning.hidden {
+	animation: none;
 }
 
 @keyframes fadeInOut {

--- a/services/frontend/src/components/Lobby/lobby.css
+++ b/services/frontend/src/components/Lobby/lobby.css
@@ -218,6 +218,10 @@
 	min-height: 32px;
 }
 
+.lobby-settings-row-powerup label {
+	text-align: right;
+}
+
 .lobby-settings-row-powerup {
 	min-height: unset;
 }


### PR DESCRIPTION
This pull request introduces a new feature to display power-up icons in the Pong game interface, along with associated styling and logic updates. The changes include modifications to the way events are handled, the addition of a new `PowerUpIcon` component, and updates to the game overlay and scores display to incorporate power-up visuals.