### PR TITLE
283 filter matchmaking users with 0 match from leaderboard

### DIFF
--- a/services/frontend/src/components/Online/ModeButton.tsx
+++ b/services/frontend/src/components/Online/ModeButton.tsx
@@ -44,7 +44,7 @@ export default function ModeButton({
 		onClick={() => onSelect(gamemode.name)}
 	>
 		{gamemode.type === GameModeType.RANKED && <div className='mode-button-mmr flex gap-1 items-center justify-center h-full'>
-			<h3>{Math.floor(rating) || "unranked"}</h3>
+			<h3>{rating !== undefined ? Math.floor(rating) : "unranked"}</h3>
 			<PopHover
 				content="Matchmaking Rating is a score that reflects your skill level in the game. It's used to match you with players of similar ability."
 				>

--- a/services/frontend/src/components/Online/ModeButton.tsx
+++ b/services/frontend/src/components/Online/ModeButton.tsx
@@ -43,18 +43,18 @@ export default function ModeButton({
 		className={`mode-button flex flex-col justify-end gap-2 ${gamemode.type} ${disabled ? 'disabled' : ''} ${selected ? 'selected' : ''}`}
 		onClick={() => onSelect(gamemode.name)}
 	>
-		{gamemode.type === GameModeType.RANKED && <div className='mode-button-mmr flex gap-1 justify-center'>
+		{gamemode.type === GameModeType.RANKED && <div className='mode-button-mmr flex gap-1 items-center justify-center h-full'>
 			<h3>{Math.floor(rating) || "unranked"}</h3>
 			<PopHover
 				content="Matchmaking Rating is a score that reflects your skill level in the game. It's used to match you with players of similar ability."
-			>
+				>
 				<i className="fa-solid fa-circle-info"></i>
 			</PopHover>
 		</div>}
 		<div className='flex gap-1 items-end'>
 			<h1>{getIcon()} {gamemode.getDisplayTypeName()}</h1>
 			{(gamemode.type === GameModeType.RANKED || gamemode.type === GameModeType.UNRANKED) && <h2>{gamemode.getDisplayName()}</h2>}
-		</div>
+			</div>
 		<p>{getDescription()}</p>
 	</div>
 }

--- a/services/frontend/src/components/Online/ModeButton.tsx
+++ b/services/frontend/src/components/Online/ModeButton.tsx
@@ -6,7 +6,7 @@ import PopHover from "../../ui/PopHover";
 export default function ModeButton({
 		gamemode,
 		onSelect,
-		rating = 200,
+		rating,
 	}: {
 		gamemode: GameMode,
 		onSelect: (mode: string) => void,
@@ -44,7 +44,7 @@ export default function ModeButton({
 		onClick={() => onSelect(gamemode.name)}
 	>
 		{gamemode.type === GameModeType.RANKED && <div className='mode-button-mmr flex gap-1 justify-center'>
-			<h3>{Math.floor(rating)}</h3>
+			<h3>{Math.floor(rating) || "unranked"}</h3>
 			<PopHover
 				content="Matchmaking Rating is a score that reflects your skill level in the game. It's used to match you with players of similar ability."
 			>

--- a/services/frontend/src/components/Online/SelectModeOverlay.tsx
+++ b/services/frontend/src/components/Online/SelectModeOverlay.tsx
@@ -70,7 +70,11 @@ export default function SelectModeOverlay({
 					className="w-fit"
 				/>
 				<div className='flex flex-row gap-4'>
-					{ranked && <ModeButton gamemode={ranked} onSelect={onSelect} rating={matchmakingUsers.find((mu) => mu.gamemode === ranked.name)?.rating} />}
+					{ranked && <ModeButton 
+						gamemode={ranked} 
+						onSelect={onSelect} 
+						rating={matchmakingUsers.find((mu) => mu.gamemode === ranked.name && mu.match_count !== 0)?.rating}
+					/>}
 					{unranked && <ModeButton gamemode={unranked} onSelect={onSelect} />}
 				</div>
 			</div>

--- a/services/frontend/src/components/Online/online.css
+++ b/services/frontend/src/components/Online/online.css
@@ -139,16 +139,15 @@
 }
 
 .mode-button-mmr {
-	align-self: center;
-	width: fit-content;
-	position: relative;
-	height: 100%;
+	width: 100%;
+	/* background-color: aqua; */
 }
 
 .mode-button-mmr h3 {
 	font-weight: bold;
-	font-size: 5rem;
+	font-size: xx-large;
 	color: var(--fg-2);
+	text-transform: capitalize;
 }
 
 .mode-button-mmr .pop-hover{
@@ -159,9 +158,5 @@
 
 .mode-button-mmr .pop-hover-container {
 	font-size: small;
-	position: absolute;
-	left: 50%;
-	transform: translateX(-50%);
-	bottom: 0px;
 	color: var(--fg-3);
 }

--- a/services/frontend/src/hooks/useMatchmackingUsers.ts
+++ b/services/frontend/src/hooks/useMatchmackingUsers.ts
@@ -7,6 +7,7 @@ export interface ImatchmakingUser {
   account_id: number,
   gamemode: string,
   rating: number,
+  match_count: number,
   created_at: string,
   updated_at: string,
 };

--- a/services/matchmaking/srcs/computeLeaderboards.js
+++ b/services/matchmaking/srcs/computeLeaderboards.js
@@ -9,6 +9,7 @@ const selectModeRankings = db.prepare(`
   SELECT account_id, rating
   FROM matchmaking_users
   WHERE gamemode = ?
+    AND match_count != 0
   ORDER BY rating DESC
   LIMIT ${LEADERBOARD_SIZE}
 `);


### PR DESCRIPTION
This pull request introduces improvements to the matchmaking feature and UI enhancements for the mode selection interface. Key changes include refining the display and logic for ranked game modes, updating the matchmaking user schema, and improving CSS styling for better user experience.

### Matchmaking Logic Updates:
* Added a `match_count` field to the `ImatchmakingUser` interface to track the number of matches played.
* Updated the leaderboard query to exclude users with zero matches from the rankings.
* Modified the `rating` logic in `SelectModeOverlay` to only consider users with non-zero `match_count`.

### UI Enhancements:
* Updated the `ModeButton` component to display "unranked" when the `rating` is undefined or zero and adjusted the layout for better alignment.
* Refined CSS styles for `.mode-button-mmr` to improve responsiveness and readability, including changes to font size, alignment, and removal of unnecessary positioning rules. [[1]](diffhunk://#diff-eac54bc3f353d6c9d093b8e0c028e160680c0260dbf8bc92690476a5c201c2b2L142-R150) [[2]](diffhunk://#diff-eac54bc3f353d6c9d093b8e0c028e160680c0260dbf8bc92690476a5c201c2b2L162-L165)

![image](https://github.com/user-attachments/assets/8896be74-c2d2-49a9-b9e4-21fa8b4a879a)
