### PR TITLE
feat: add social/credentials database indexes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ $(SSL_CERTIFICATE):
 		-keyout secrets/localhost.key \
 		-subj "/C=FR/ST=Rhone-Alpes/L=Lyon/O=YATT/OU=IT Department/CN=www.localhost.com"
 
-test:
+test: $(SERVICES_DEPS)
 	(cd ./tests && npm i)
 	npm --prefix ./tests run test
 

--- a/services/credentials/srcs/app/database.js
+++ b/services/credentials/srcs/app/database.js
@@ -27,6 +27,8 @@ db.exec(`
   END;
 `);
 
+db.exec(`CREATE INDEX IF NOT EXISTS idx_accounts_auth_method ON accounts (auth_method)`);
+
 // Password authentication
 db.exec(`
   CREATE TABLE IF NOT EXISTS password_auth (
@@ -66,5 +68,7 @@ db.exec(`
   FOREIGN KEY (account_id) REFERENCES accounts(account_id) ON DELETE CASCADE
   )
 `)
+
+db.exec(`CREATE INDEX IF NOT EXISTS idx_otp_methods_account_id ON otp_methods (account_id)`);
 
 export default db;

--- a/services/social/srcs/app/database.js
+++ b/services/social/srcs/app/database.js
@@ -45,6 +45,8 @@ db.exec(`
   )
 `);
 
+db.exec(`CREATE INDEX IF NOT EXISTS idx_friendships_user2 ON friendships (user2)`);
+
 // blocks table
 db.exec(`
   CREATE TABLE IF NOT EXISTS blocks (


### PR DESCRIPTION
This pull request introduces new indexes in various database tables.

### Database performance enhancements:
* [`services/credentials/srcs/app/database.js`](diffhunk://#diff-1767acbeebf3b7f893a0df30d96b286337475d09128292c020255bdba932d9e1R30-R31): Added an index `idx_accounts_auth_method` on the `auth_method` column in the `accounts` table to optimize queries involving authentication methods.
* [`services/credentials/srcs/app/database.js`](diffhunk://#diff-1767acbeebf3b7f893a0df30d96b286337475d09128292c020255bdba932d9e1R72-R73): Added an index `idx_otp_methods_account_id` on the `account_id` column in the `otp_methods` table to improve the performance of account-related OTP queries.
* [`services/social/srcs/app/database.js`](diffhunk://#diff-4a85cb39f12634f21d8f21a9453a042af8cdbdcf688a61ad0e8d4056fa7de099R48-R49): Added an index `idx_friendships_user2` on the `user2` column in the `friendships` table to enhance the efficiency of friendship-related queries.