### PR TITLE
Remove overlay from fortytwo view

### DIFF
--- a/services/frontend/src/contexts/useOverlay.tsx
+++ b/services/frontend/src/contexts/useOverlay.tsx
@@ -25,11 +25,14 @@ export const OverlayProvider = ({ children } : {children?: any}) => {
 				toggleOverlay: () => setIsForcedOpen(prev => !prev),
 			}}
 		>
-			<Overlay
-				hidden={hidden}
-			>
-				{children}
-			</Overlay>
+			{
+				location.pathname.startsWith('/fortytwo') ? children :
+				<Overlay
+					hidden={hidden}
+				>
+					{children}
+				</Overlay>
+			}
 		</OverlayContext.Provider>
 	);
 };


### PR DESCRIPTION
This pull request modifies the `OverlayProvider` component in `useOverlay.tsx` to conditionally render its children directly if the current path starts with `/fortytwo`. Otherwise, it wraps the children in an `Overlay` component.

Key change:

* [`services/frontend/src/contexts/useOverlay.tsx`](diffhunk://#diff-ef313ba903fc98ce84ecf5a87e42ad3ba996d57e730b781f7c35ff29e25115ceR28-R35): Updated the `OverlayProvider` to check if the `location.pathname` starts with `/fortytwo`. If true, it directly renders the `children`. Otherwise, it wraps the `children` within the `Overlay` component.