### PR TITLE
fix: ping every 5s in Online view

### DIFF
--- a/services/frontend/src/hooks/useWebSocket.ts
+++ b/services/frontend/src/hooks/useWebSocket.ts
@@ -78,7 +78,12 @@ export default function useWebSocket({
 	};
 
 	const send = (message: string | object) => {
-		ws.current.send(JSON.stringify(message));
+		try {
+			ws.current.send(JSON.stringify(message));
+		}
+		catch (error) {
+			console.error("Error sending message:", error);
+		}
 	};
 
 	return {

--- a/services/frontend/src/views/OnlineView.tsx
+++ b/services/frontend/src/views/OnlineView.tsx
@@ -3,11 +3,13 @@ import { usePong } from "../contexts/usePong";
 import { useParams } from "babact-router-dom";
 import GameOverlay from "../components/Game/GameOverlay";
 import { APIRefreshToken } from "../hooks/useAPI";
+import { useAuth } from "../contexts/useAuth";
 
 export default function OnlineView() {
 
 	const { app, overlay } = usePong();
 	const { id } = useParams();
+	const { ping } = useAuth();
 
 	const connect = async () => {
 		await APIRefreshToken();
@@ -17,6 +19,15 @@ export default function OnlineView() {
 	Babact.useEffect(() => {
 		connect();
 	}, [id]);
+
+	Babact.useEffect(() => {
+		const interval = setInterval(() => {
+			ping();
+		}, 5000);
+		return () => {
+			clearInterval(interval);
+		};
+	}, []);
 
 	if (!overlay)
 		return;


### PR DESCRIPTION
This pull request introduces a periodic authentication check in the `OnlineView` component to enhance session management. The key changes include importing the `useAuth` hook and adding a `setInterval` to call the `ping` method every 5 seconds.

### Enhancements to session management:

* [`services/frontend/src/views/OnlineView.tsx`](diffhunk://#diff-6bfa8b003318a56b247fe6fbc8f80930386d4c71feb1a13cb2373e847bfdc18bR6-R12): Added the `useAuth` hook to the imports and integrated a `setInterval` inside a `useEffect` to call the `ping` method every 5 seconds. This ensures periodic authentication checks to maintain session validity. [[1]](diffhunk://#diff-6bfa8b003318a56b247fe6fbc8f80930386d4c71feb1a13cb2373e847bfdc18bR6-R12) [[2]](diffhunk://#diff-6bfa8b003318a56b247fe6fbc8f80930386d4c71feb1a13cb2373e847bfdc18bR23-R31)