### PR TITLE
eval compose override

### DIFF
--- a/docker-compose.eval.yaml
+++ b/docker-compose.eval.yaml
@@ -14,6 +14,10 @@ services:
       - ssl-crt
       - ssl-key
   
+  avatars:
+    environment:
+      - NODE_TLS_REJECT_UNAUTHORIZED=0
+  
 secrets:
   ssl-crt: 
     file: ./secrets/localhost.crt


### PR DESCRIPTION
This pull request fixes the evaluation environment setup, where an envar was missing for the avatar service