### PR TITLE
fix: Multiball server side

### DIFF
--- a/modules/pong/src/core/MultiBallPongEvent.ts
+++ b/modules/pong/src/core/MultiBallPongEvent.ts
@@ -9,7 +9,7 @@ import * as K from './constants.js';
 
 export default class MultiBallPongEvent extends PongEvent {
 	constructor() {
-		super(PongEventType.MULTIBALL, PongEventScope.GLOBAL, PongEventActivationSide.BOTH, 100);	
+		super(PongEventType.MULTIBALL, PongEventScope.GLOBAL, PongEventActivationSide.SERVER, 100);	
 	}
 
 	public override activate(game: Pong, playerId: PlayerID): boolean {

--- a/modules/yatt-lobbies/src/Lobby.ts
+++ b/modules/yatt-lobbies/src/Lobby.ts
@@ -85,8 +85,6 @@ export const defaultMatchParameters: IMatchParameters = {
     PongEventType.MULTIBALL,
     PongEventType.ATTRACTOR,
     PongEventType.ICE,
-    // PongEventType.BIGPADDLE,
-    // PongEventType.SMALLPADDLE,
   ],
   ball_speed: 1,
   point_to_win: 3


### PR DESCRIPTION
This pull request includes changes to the behavior of the `MultiBallPongEvent` class and updates to the default match parameters in the lobby configuration. The most important updates involve modifying the activation side for the `MultiBallPongEvent` and removing commented-out event types from the default match parameters.

### Changes to `MultiBallPongEvent`:

* Modified the activation side of the `MultiBallPongEvent` from `PongEventActivationSide.BOTH` to `PongEventActivationSide.SERVER` to ensure the event is only activated on the server side. (`modules/pong/src/core/MultiBallPongEvent.ts`, [modules/pong/src/core/MultiBallPongEvent.tsL12-R12](diffhunk://#diff-0f20651dcc1c31a4aa75d0338f92005ee98ecf3f32cfe05d145b667f7e89e96eL12-R12))

### Updates to default match parameters:

* Removed commented-out event types (`PongEventType.BIGPADDLE` and `PongEventType.SMALLPADDLE`) from the `defaultMatchParameters` configuration, cleaning up unused code. (`modules/yatt-lobbies/src/Lobby.ts`, [modules/yatt-lobbies/src/Lobby.tsL88-L89](diffhunk://#diff-ba58eac5edeb9b7092778be07f4da56507a0cb37d885bc868201f802c4670733L88-L89))