### PR TITLE
fix: capped resolution to 1080p

### DIFF
--- a/services/frontend/src/components/Babylon/PongClient.ts
+++ b/services/frontend/src/components/Babylon/PongClient.ts
@@ -391,6 +391,9 @@ export default class PongClient extends PONG.Pong {
 	}
 
 	private loop = () => {
+		this._canvas.width = 1920;
+		this._canvas.height = this._canvas.width / (this._babylonScene.scene.getEngine().getAspectRatio(this._babylonScene.camera));
+		this._babylonScene.scene.getEngine().resize();
 		let dt: number = this._engine.getDeltaTime() / 1000;
 		this._keyboard.update();
 		this._babylonScene.updateCamera(dt);


### PR DESCRIPTION
This pull request includes a change to the `PongClient` class to improve the rendering behavior by dynamically adjusting the canvas size based on the aspect ratio of the scene's camera.

Rendering improvement:

* [`services/frontend/src/components/Babylon/PongClient.ts`](diffhunk://#diff-5b1ef1eba53a7fd9dbd7692a3f4ec555374a36b944d8410e298afad553f35702R394-R396): Updated the `loop` method to dynamically set the canvas width to 1920 and calculate the height based on the aspect ratio of the camera. The engine is resized accordingly to ensure proper rendering.