### PR TITLE
fix: disable panning

### DIFF
--- a/services/frontend/src/components/Babylon/PongScene.ts
+++ b/services/frontend/src/components/Babylon/PongScene.ts
@@ -81,6 +81,7 @@ export default class PongScene {
 		this.camera.inputs.addMouseWheel();
 		this.camera.inputs.addPointers();
 		this.camera.attachControl(this._canvas, true);
+		this.camera.panningSensibility = 0;
 		this.camera.upperBetaLimit = 85 * Math.PI / 180;
 		this.camera.lowerRadiusLimit = 10;
 		this.camera.upperRadiusLimit = 30;
@@ -444,7 +445,8 @@ export default class PongScene {
 			this.camera.inputs.addMouseWheel();
 			this.camera.inputs.addPointers();
 			this.camera.attachControl(this._canvas, true);
-		} else { // loose camera control
+			this.camera.panningSensibility = 0;
+		} else { // lose camera control
 			this.camera.detachControl();
 		}
 	}


### PR DESCRIPTION
This pull request introduces changes to the `PongScene` class in `services/frontend/src/components/Babylon/PongScene.ts` to adjust camera behavior and fix a typo in a comment.

### Camera behavior adjustments:
* Added `panningSensibility = 0` to the camera configuration to disable panning sensitivity in both the default setup and conditional logic for camera control. [[1]](diffhunk://#diff-9ff1538ad089da7bbff121a25daa670ffaa3001545fe984e31f717c96b8bd94aR84) [[2]](diffhunk://#diff-9ff1538ad089da7bbff121a25daa670ffaa3001545fe984e31f717c96b8bd94aL447-R449)

### Comment typo fix:
* Corrected a typo in a comment, changing "loose camera control" to "lose camera control."