### PR TITLE
fix: was re-enabling the whole map

### DIFF
--- a/services/frontend/src/components/Babylon/PongClient.ts
+++ b/services/frontend/src/components/Babylon/PongClient.ts
@@ -328,13 +328,14 @@ export default class PongClient extends PONG.Pong {
 				object.disable();
 			}
 		});
+		if (this._babylonScene.meshMap.get(mapId)?.ground !== null) {
+			this._babylonScene.meshMap.get(mapId)?.ground.setEnabled(true);
+		}
 		// this._babylonScene.shadowGenerator.getShadowMap().resetRefreshCounter();
 	}
 
 	private preloadScene() {
 		this.preloadSetup();
-
-		this._babylonScene.enableMap(this._currentMap.mapId);
 
 		this._player = undefined;
 		this.bindPaddles();
@@ -345,8 +346,6 @@ export default class PongClient extends PONG.Pong {
 	private menuScene() {
 		this.menuSetup();
 		
-		this._babylonScene.enableMap(this._currentMap.mapId);
-		
 		this._player = undefined;
 		this._babylonScene.updateMeshes(0);
 		this._babylonScene.switchCamera();
@@ -355,8 +354,6 @@ export default class PongClient extends PONG.Pong {
 	
 	private localScene() {
 		this.localSetup();
-
-		this._babylonScene.enableMap(this._currentMap.mapId);
 
 		this._player = undefined;
 		this.bindPaddles();
@@ -367,8 +364,6 @@ export default class PongClient extends PONG.Pong {
 	
 	private onlineScene(match_id: number, gamemode: GameMode, players: IPlayer[], matchParameters: IMatchParameters, state?: PONG.PongState) {
 		this.onlineSetup(match_id, gamemode, players, matchParameters, state);
-
-		this._babylonScene.enableMap(this._currentMap.mapId);
 	
 		this.bindPaddles();
 		this._babylonScene.updateMeshes(0);


### PR DESCRIPTION
This pull request refactors the `PongClient` class in `PongClient.ts` to improve scene management by removing redundant map enabling calls and adding a conditional check for enabling the ground mesh. The changes streamline the code and ensure better control over scene updates.

### Scene Management Improvements:
* Added a conditional check to enable the ground mesh in the Babylon scene if it exists. ([services/frontend/src/components/Babylon/PongClient.tsR331-L338](diffhunk://#diff-5b1ef1eba53a7fd9dbd7692a3f4ec555374a36b944d8410e298afad553f35702R331-L338))
* Removed redundant calls to `this._babylonScene.enableMap(this._currentMap.mapId)` from the `preloadScene`, `menuScene`, `localScene`, and `onlineScene` methods, as these calls were unnecessary for the intended functionality. ([[1]](diffhunk://#diff-5b1ef1eba53a7fd9dbd7692a3f4ec555374a36b944d8410e298afad553f35702L348-L349)`, `[[2]](diffhunk://#diff-5b1ef1eba53a7fd9dbd7692a3f4ec555374a36b944d8410e298afad553f35702L359-L360), [[3]](diffhunk://#diff-5b1ef1eba53a7fd9dbd7692a3f4ec555374a36b944d8410e298afad553f35702L371-L372))